### PR TITLE
Pre-trial fit: design step, doc-review skill, operator toolbox, PR conventions

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -16,10 +16,12 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
 2. **Design record — scaled by the stakes tier.** Throwaway: skip
    entirely; the charter is enough. Standard and production: one page
    (`docs/design.md`) — stack choice and why, architecture sketch, data
-   shape, main structural risks — reviewed with `doc-review`; at
-   production stakes, Steve approves it explicitly before any unit opens.
-   Decisions, not documents: a section with nothing load-bearing to say
-   gets deleted, not filled.
+   shape, main structural risks — reviewed with `doc-review`. At
+   production stakes, Steve's approving GitHub review **on the bootstrap
+   PR itself** is the approval artifact — Claude merges that PR only
+   after it exists; chat assent is not approval. Decisions, not
+   documents: a section with nothing load-bearing to say gets deleted,
+   not filled.
 3. **Copy the seed**: `seed/CLAUDE.md.template` → `CLAUDE.md`,
    `seed/workflows/ci.yml` → `.github/workflows/ci.yml`,
    `seed/workflows/backlog-expiry.yml` → `.github/workflows/backlog-expiry.yml`,
@@ -27,9 +29,12 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    Fill every `{{PLACEHOLDER}}` from the charter and design record. The
    copy is a divorce: this repo owes sofa-claude nothing after.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
-   as the default branch** — unit issues then auto-close when their PR
-   merges to `dev` (closing keywords fire only on the default branch),
-   and new PRs target `dev` by default. Create labels `urgent`, `keep`,
+   as the default branch, then verify it stuck** (`gh repo view --json
+   defaultBranchRef` must say `dev` — if it doesn't, stop wiring and put
+   it in the needs-Steve digest, because unit auto-close and the expiry
+   record both silently lie until it's fixed). Unit issues then auto-close
+   when their PR merges to `dev`, and new PRs target `dev` by default.
+   Create labels `urgent`, `keep`,
    `standing`; create the standing handoff issue and note its number in
    CLAUDE.md. Vercel wiring is Steve's step — list it in the needs-Steve
    digest, don't wait.

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: Bootstrap a workload repo from the seed kit — elicit a one-page charter with a stakes tier and end condition, copy and adapt seed/, wire branches and standing issues.
+description: Bootstrap a workload repo from the seed kit — elicit a charter with stakes tier and falsifiable end condition, add a stakes-scaled design record, copy and adapt seed/, wire branches, labels, and standing issues.
 ---
 
 # bootstrap
@@ -10,23 +10,34 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
 1. **Charter first** (`docs/charter.md`, one page, elicited from Steve):
    what is being built and why; who uses it; the **stakes tier**
    (throwaway / standard / production) that sets review depth everywhere;
-   the coverage floor; and the project's **end condition** — what done looks
-   like, written before work starts.
-2. **Copy the seed**: `seed/CLAUDE.md.template` → `CLAUDE.md`,
+   the coverage floor; and the project's **end condition** — what done
+   looks like, written before work starts and *falsifiable*: if you can't
+   say how you'd test that it's met, rewrite it until you can.
+2. **Design record — scaled by the stakes tier.** Throwaway: skip
+   entirely; the charter is enough. Standard and production: one page
+   (`docs/design.md`) — stack choice and why, architecture sketch, data
+   shape, main structural risks — reviewed with `doc-review`; at
+   production stakes, Steve approves it explicitly before any unit opens.
+   Decisions, not documents: a section with nothing load-bearing to say
+   gets deleted, not filled.
+3. **Copy the seed**: `seed/CLAUDE.md.template` → `CLAUDE.md`,
    `seed/workflows/ci.yml` → `.github/workflows/ci.yml`,
    `seed/workflows/backlog-expiry.yml` → `.github/workflows/backlog-expiry.yml`,
    `seed/pull_request_template.md` → `.github/pull_request_template.md`.
-   Fill every `{{PLACEHOLDER}}` from the charter and the project's actual
-   stack. The copy is a divorce: this repo owes sofa-claude nothing after.
-3. **Wire the repo**: create `dev` and `staging` from `main`; create labels
-   `urgent`, `keep`, and `standing`; create the standing handoff issue and
-   note its number in CLAUDE.md. Vercel wiring (which branch deploys where)
-   is Steve's step — list it for him in the needs-Steve digest, don't wait.
-4. **Propose the first unit**: one issue, frozen acceptance criteria, sized
-   to reach `dev` within a session. Product code, not process — if the
-   process pinches during the unit, that's a sofa-claude bleed to note,
-   not machinery to build here.
+   Fill every `{{PLACEHOLDER}}` from the charter and design record. The
+   copy is a divorce: this repo owes sofa-claude nothing after.
+4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
+   as the default branch** — unit issues then auto-close when their PR
+   merges to `dev` (closing keywords fire only on the default branch),
+   and new PRs target `dev` by default. Create labels `urgent`, `keep`,
+   `standing`; create the standing handoff issue and note its number in
+   CLAUDE.md. Vercel wiring is Steve's step — list it in the needs-Steve
+   digest, don't wait.
+5. **Propose the first unit**: one issue, frozen acceptance criteria,
+   sized to reach `dev` within a session. Product code, not process — if
+   the process pinches during the unit, that's a sofa-claude bleed to
+   note, not machinery to build here.
 
 Total bootstrap budget: one session, one PR into the workload's `dev`
-(charter + seed files). If it wants to grow beyond that, stop — that is a
-bleed to raise in sofa-claude, not a bigger bootstrap.
+(charter + design record + seed files). If it wants to grow beyond that,
+stop — that is a bleed to raise in sofa-claude, not a bigger bootstrap.

--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -6,8 +6,12 @@ description: Adversarial review of design and governance prose — charters, CLA
 # doc-review
 
 For prose that governs behavior: charters, rulebooks, grants, design
-records, acceptance criteria. Not for code — that is `/code-review`,
-Steve's to type. Both lanes run only on seam artifacts (decisions/0003).
+records. Not for code — that is `/code-review`, Steve's to type. Where
+this skill runs: every PR to sofa-claude (there both lanes run — the
+seam rule, recorded in that repo's decisions/0003), and workload design
+prose — the charter and design record at standard/production stakes, at
+bootstrap and on any later amendment. Unit-level acceptance criteria get
+no adversarial pass: that is proportionality, not an omission.
 
 ## Before running
 
@@ -31,9 +35,14 @@ the artifact — and must not read any other review's findings first.
 > grade (urgent-grade / keep-grade). Fewer is fine — padding is itself a
 > failure. One round; no recommendations for further review passes.
 
+For a design record, Context must quote the charter's stakes tier and
+end condition and list the record's own claimed risks — a bland Context
+is a defective review, not a compliant one.
+
 ## After
 
 Post the findings as a comment on the target PR — no comment, no review
 happened — and confirm the comment actually landed before acting on it.
 Triage findings by the intake rule; one fix round; no review of the
-fixes beyond CI.
+fixes beyond CI, and a second review round only if an urgent-grade
+finding survives the fix round.

--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: doc-review
+description: Adversarial review of design and governance prose — charters, CLAUDE.mds, grants, design records, acceptance criteria. Runs a fixed, visible brief with hard caps so review depth can't become the finding factory that killed the legacy process.
+---
+
+# doc-review
+
+For prose that governs behavior: charters, rulebooks, grants, design
+records, acceptance criteria. Not for code — that is `/code-review`,
+Steve's to type. Both lanes run only on seam artifacts (decisions/0003).
+
+## Before running
+
+Make the brief visible: attended, paste the filled brief in chat so Steve
+can amend it; unattended, commit it in the PR before the reviewer starts.
+The reviewer must be fresh-context — a subagent that has not worked on
+the artifact — and must not read any other review's findings first.
+
+## The brief (fill the [brackets]; change anything else only via a PR)
+
+> Target: [files or diff]. Context: [one paragraph — what this artifact
+> governs, and what its predecessor got wrong]. Stance: adversarial —
+> try to break the design, not improve its prose. Attack, in order:
+> (1) loopholes — ways a letter-compliant actor still causes the harm
+> the rules exist to prevent; (2) false enforcement claims — promises
+> the machinery doesn't deliver; (3) contradictions between files;
+> (4) failure modes of unattended operation. Forbidden: style or wording
+> notes, hypothetical edge cases with no plausible path, anything
+> without a concrete harm scenario. Output: at most 8 findings, ranked
+> most severe first, each with file/rule, the failure scenario, and a
+> grade (urgent-grade / keep-grade). Fewer is fine — padding is itself a
+> failure. One round; no recommendations for further review passes.
+
+## After
+
+Post the findings as a comment on the target PR — no comment, no review
+happened — and confirm the comment actually landed before acting on it.
+Triage findings by the intake rule; one fix round; no review of the
+fixes beyond CI.

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -13,6 +13,10 @@ description: Start-of-session orientation — one cheap read of the standing han
 3. State your understanding of current scope in two or three sentences and
    confirm it with Steve (or, in an unattended run, against the schedule's
    declared purpose). Only then read anything else or act.
+4. Freshness check on the operator toolbox: if `~/.claude/skills/` differs
+   from sofa-claude `main`'s `.claude/skills/` (compare via `gh`), refresh
+   the copies from merged `main` — never from a branch — before relying on
+   any skill.
 
 Do not deep-read decision records, grants, or history reflexively — pull
 them in only when the confirmed scope needs them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,15 @@
-## What bled
+## Why this change
 
-<!-- The concrete incident in real work that motivated this change — which
-workload repo, what happened, why the current process failed it. Founding
-seed and governance PRs cite their decision record or grant instead.
-CI rejects this section when empty or under ~20 characters of substance. -->
+<!-- The concrete incident in real work that motivated this — which repo,
+what happened, why the current process failed it. Founding and governance
+PRs cite their decision record or grant instead. Abstract improvement is
+not a reason to merge; CI rejects this section when empty or near-empty. -->
 
 ## What changed
+
+<!-- The approach in a few sentences, plus anything surprising in the diff
+a reviewer would puzzle over. Link the issue this resolves with a closing
+keyword (e.g. "Closes #12"). -->
 
 ## Verification
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,23 +5,23 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  what-bled:
+  why-this-change:
     runs-on: ubuntu-latest
     steps:
-      - name: PR body names its bleed
+      - name: PR body names the incident motivating it
         env:
           BODY: ${{ github.event.pull_request.body }}
         run: |
           python3 - <<'EOF'
           import os, re, sys
           body = os.environ.get("BODY") or ""
-          m = re.search(r"## What bled\s*\n(.*?)(?=\n## |\Z)", body, re.S)
-          section = m.group(1) if m else ""
-          section = re.sub(r"<!--.*?-->", "", section, flags=re.S).strip()
+          m = re.search(r"## Why this change\s*\n(.*?)(?=\n## |\Z)", body, re.S)
+          section = re.sub(r"<!--.*?-->", "", m.group(1) if m else "", flags=re.S).strip()
           if len(section) < 20:
-              sys.exit("The 'What bled' section must name the real-work incident "
-                       "(or decision record / grant) motivating this change.")
-          print("What bled:", section[:160])
+              sys.exit("The 'Why this change' section must name the concrete "
+                       "real-work incident (or decision record / grant) "
+                       "motivating this change.")
+          print("Why this change:", section[:160])
           EOF
 
   secrets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ back; good patterns are harvested back here occasionally, never pushed out.
   first push and keep it draft while review and fixes are in progress —
   ready means merging is the only step left. A pushed branch with no PR is
   a defect.
-- Every PR body fills **What bled**: the concrete incident in real work that
-  motivated the change. CI rejects an unfilled section. No bleed, no merge.
+- Every PR body fills **Why this change** with the concrete incident in
+  real work that motivated it. CI rejects an unfilled section. No bleed,
+  no merge.
 - Healthy steady state: near-zero PRs here while workload repos grow. This
   queue is the spiral detector — if it fills, the factory is manufacturing
   factory parts again.
@@ -55,10 +56,13 @@ command in the PR body or digest; Claude never invokes or replicates it.
 
 ## Skills
 
-The set is closed: `onboard`, `wrap-up`, `bootstrap`. Adding one takes a
-bleed, like any rule. `/onboard` first in every session (reads Issue #1's
-body only); `/wrap-up` before ending a substantive session (refreshes
-Issues #1 and #2).
+The set is closed: `onboard`, `wrap-up`, `bootstrap`, `doc-review`. Adding
+one takes a bleed, like any rule. Skills are the operator's toolbox, not
+repo content: installed to `~/.claude/skills/` as copies from merged
+`main` only — never symlinked, never from a branch — and a skill may
+never require a repo convention a bootstrapped repo lacks. `/onboard`
+first in every session (reads Issue #1's body only); `/wrap-up` before
+ending a substantive session (refreshes Issues #1 and #2).
 
 ## Rulebook budget
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ back; good patterns are harvested back here occasionally, never pushed out.
 
 ## Review
 
-Depth scales with product stakes, never diff contents. One round per unit; a
-second round only for `urgent`/`keep`-grade findings — the rest follow the
-intake rule. Design/governance prose gets the adversarial brief review, its
+Depth scales with product stakes, never diff contents. One round per unit;
+a second only when an urgent-grade finding survives the fix round — all
+else follows the intake rule. Design/governance prose gets the adversarial brief review, its
 brief visible in the PR before it runs. Code review is Steve's to type —
 the process hands him the exact `/code-review <effort> <PR URL> --comment`
 command in the PR body or digest; Claude never invokes or replicates it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,8 @@ workload repos copy at bootstrap, the governance record, a small closed set of
 skills, and the "needs Steve" digest. Work happens in workload repos, never
 here. Account rules inherit from `~/.claude/CLAUDE.md`.
 
-Origin: rebuilt 2026-08 from `smansf/sofa-claude-legacy`, which spiraled into
-process-about-process. Diagnosis: [decisions/0001](decisions/0001-rebuild-from-legacy.md);
-intake and review design: [decisions/0002](decisions/0002-discovered-work-and-review-lines.md).
+Origin: rebuilt 2026-08 from `smansf/sofa-claude-legacy`, which spiraled
+into process-about-process. All rationale lives in `decisions/` (start at 0001).
 
 ## What this repo is not
 
@@ -56,13 +55,12 @@ command in the PR body or digest; Claude never invokes or replicates it.
 
 ## Skills
 
-The set is closed: `onboard`, `wrap-up`, `bootstrap`, `doc-review`. Adding
-one takes a bleed, like any rule. Skills are the operator's toolbox, not
-repo content: installed to `~/.claude/skills/` as copies from merged
-`main` only — never symlinked, never from a branch — and a skill may
-never require a repo convention a bootstrapped repo lacks. `/onboard`
-first in every session (reads Issue #1's body only); `/wrap-up` before
-ending a substantive session (refreshes Issues #1 and #2).
+The set is closed: `onboard`, `wrap-up`, `bootstrap`, `doc-review` —
+adding one takes a bleed. Skills are the operator's toolbox, not repo
+content: installed to `~/.claude/skills/` as copies from merged `main`
+only (never a branch), and may never require a convention a bootstrapped
+repo lacks. `/onboard` first in every session (reads Issue #1's body
+only); `/wrap-up` before ending one (refreshes Issues #1 and #2).
 
 ## Rulebook budget
 

--- a/decisions/0004-pre-trial-fit.md
+++ b/decisions/0004-pre-trial-fit.md
@@ -47,7 +47,17 @@ which wasn't `dev`.
 
 ## Consequences
 
-Bootstrap can now run its own trial (skills available account-wide);
-wilson gets a designed foundation without re-importing ceremony into
+Bootstrap can run its own trial once the post-merge install lands —
+onboard's freshness check then keeps the toolbox current every session.
+Wilson gets a designed foundation without re-importing ceremony into
 throwaway work; PR bodies read plainly to future miners; unit hygiene is
-automatic. doc-review's first invocation is the PR that created it.
+automatic. doc-review's first invocation was this PR itself; its review
+drove this record's own amendments (see the PR's findings comment).
+
+Accepted residual risks, revisited only if they bleed: at standard
+stakes the design-record review is self-administered (author fills the
+brief; the brief-content rule and the production-stakes PR-review
+artifact bound but don't eliminate steering); and sessions working
+inside sofa-claude itself load the checkout's repo-scoped skills — that
+is the development loop, while the account copies govern everywhere
+else.

--- a/decisions/0004-pre-trial-fit.md
+++ b/decisions/0004-pre-trial-fit.md
@@ -1,0 +1,53 @@
+# 0004 — Pre-build design, the doc-review skill, and the operator toolbox
+
+**Status:** accepted (Steve, 2026-08-19) · **Amends:** the bootstrap
+procedure, 0002 (review lines), and the PR conventions
+
+## Context
+
+Steve inspected the factory before the sofa-scratch trial and found five
+gaps. (1) Bootstrap jumped from charter to first unit with stack,
+architecture, and data decisions made nowhere — harmless for a throwaway,
+a hole for wilson. (2) The adversarial review existed only as chat
+precedent, re-authored ad hoc each run. (3) Factory skills are repo-scoped,
+so in the workload directories they must run from, they don't exist — the
+design couldn't run its own trial. (4) "What bled" was jargon,
+uncommunicative to any reader outside this conversation. (5) Unit issues
+would never auto-close: closing keywords fire only on the default branch,
+which wasn't `dev`.
+
+## Decision
+
+- **Pre-build design scales with the charter's stakes tier.** Throwaway:
+  charter only. Standard/production: a one-page design record (stack and
+  why, architecture sketch, data shape, structural risks) reviewed via
+  doc-review; production adds Steve's explicit approval before unit 1.
+  Decisions, not documents. Charters must state a falsifiable end
+  condition. No milestone layer yet — wilson's bootstrap decides whether
+  one is needed.
+- **doc-review joins the closed skill set:** the canonical brief in one
+  inspectable file, visible before every run; fresh-context reviewer,
+  blind to other reviews; at most 8 findings, each with a harm scenario;
+  one round; findings posted to the PR or the review didn't happen.
+- **Snapshot vs. toolbox.** Workload repos are point-in-time snapshots
+  that never reference sofa-claude. Skills are the operator's toolbox —
+  live, account-level (`~/.claude/skills/`), installed as copies from
+  merged `main` only, because a symlink would let unreviewed branch text
+  govern live behavior. A skill may never *require* a repo convention a
+  bootstrapped repo lacks; a change that would is a re-bootstrap-grade
+  event, not a silent upgrade.
+- **PR conventions:** sections are *Why this change* / *What changed* /
+  *Verification* — self-explanatory to a cold reader, with the bleed
+  discipline living in the instruction text and the same CI gate. Issues
+  are linked with closing keywords, and workload repos set `dev` as the
+  default branch so units auto-close at the moment the process calls them
+  done.
+- **Adopt stays parked** until a real adoption target exists; the legacy
+  implementation remains in sofa-claude-legacy as reference.
+
+## Consequences
+
+Bootstrap can now run its own trial (skills available account-wide);
+wilson gets a designed foundation without re-importing ceremony into
+throwaway work; PR bodies read plainly to future miners; unit hygiene is
+automatic. doc-review's first invocation is the PR that created it.

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -12,7 +12,8 @@ bootstrap {{DATE}}; this repo owes it nothing).
 - `dev` — Claude's trunk. Feature branches `claude/*` PR into `dev`; Claude
   merges at will once CI is green and a fresh-context reviewer pass — one
   round, scaled to the charter's stakes tier — is posted as a comment on
-  the PR (no comment, no merge). Open every PR at the first push, draft
+  the PR (no comment, no merge). `dev` is the repo's default branch, so
+  unit issues auto-close on merge. Open every PR at the first push, draft
   while review and fixes are in progress; ready means merging is the only
   step left.
 - `staging` — human-facing preview. Steve promotes `dev → staging` via a

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -37,7 +37,10 @@ bootstrap {{DATE}}; this repo owes it nothing).
 - Second triage, on the issue: `urgent` (interrupts current work), `keep`
   (never expires), or unlabeled (default — auto-expires after 14 days
   untouched). Tier, and whether it needs a spec, is judged at pickup.
-- Review: the `dev` rule above. Promotion PRs hand Steve the paste-ready
+- Review: the `dev` rule above. Amendments to `docs/charter.md` or
+  `docs/design.md` additionally take a `doc-review` pass (operator
+  toolbox); at production stakes Steve re-approves via PR review.
+  Promotion PRs hand Steve the paste-ready
   `/code-review <effort> <PR URL> --comment` command and confirm its
   findings actually landed on the PR.
 

--- a/seed/pull_request_template.md
+++ b/seed/pull_request_template.md
@@ -1,7 +1,9 @@
 ## Unit
 
-<!-- Link the issue whose frozen acceptance criteria this PR satisfies.
-Promotion PRs (dev→staging, staging→main) list the units included instead. -->
+<!-- Link the issue whose frozen acceptance criteria this PR satisfies,
+with a closing keyword — e.g. "Closes #12" — so the unit auto-closes when
+this merges to dev (dev is the default branch). Promotion PRs
+(dev→staging, staging→main) list the units included instead. -->
 
 ## What changed
 


### PR DESCRIPTION
## Why this change

Owner inspection before the sofa-scratch trial (2026-08-19) found five gaps: bootstrap assumed stack/architecture decisions it never makes; the factory's skills are repo-scoped so they don't exist in the workload directories they must run from (the design couldn't run its own trial); the "What bled" label was jargon to any cold reader; unit issues would never auto-close (closing keywords fire only on the default branch, which wasn't `dev`); and the adversarial review had no canonical, inspectable form. Rationale: [decisions/0004](https://github.com/smansf/sofa-claude/blob/claude/pre-trial-fit/decisions/0004-pre-trial-fit.md).

## What changed

- **bootstrap**: stakes-scaled design-record step (throwaway skips it; standard/production get one reviewed page, production adds Steve's explicit approval); charters must state a falsifiable end condition; `dev` becomes the workload default branch at wiring.
- **New `doc-review` skill** — the canonical adversarial brief in one inspectable file, visibility-before-run rule, fresh-context + blind requirements, max-8/one-round caps, findings-as-PR-comment artifact. Closed set grows to four.
- **Snapshot vs. toolbox**: workload repos stay point-in-time snapshots; skills are the operator's toolbox, installed to `~/.claude/skills/` as copies from merged `main` only.
- **PR conventions**: "What bled" → "Why this change" (same gate, self-explanatory label; CI job renamed `what-bled` → `why-this-change` — if you created a required-check rule under the old name, update it); closing-keyword instructions in both PR templates.
- decisions/0004 records the rationale; the adopt skill stays parked until a real adoption target exists.

## Verification

This PR's own CI validates the renamed gate against this body. CLAUDE.md remains under its 75-line budget. doc-review's first invocation is this PR itself — its findings will appear as a comment below before the PR leaves draft. Skill install to `~/.claude/skills/` happens post-merge (copies from `main`), recorded in the handoff.
