### PR TITLE
Determinism pass: line-budget gate, paved-path dev merge, unit issue form

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -25,7 +25,9 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
 3. **Copy the seed**: `seed/CLAUDE.md.template` → `CLAUDE.md`,
    `seed/workflows/ci.yml` → `.github/workflows/ci.yml`,
    `seed/workflows/backlog-expiry.yml` → `.github/workflows/backlog-expiry.yml`,
-   `seed/pull_request_template.md` → `.github/pull_request_template.md`.
+   `seed/pull_request_template.md` → `.github/pull_request_template.md`,
+   `seed/ISSUE_TEMPLATE/unit.yml` → `.github/ISSUE_TEMPLATE/unit.yml`,
+   `seed/scripts/merge_dev.py` → `scripts/merge_dev.py`.
    Fill every `{{PLACEHOLDER}}` from the charter and design record. The
    copy is a divorce: this repo owes sofa-claude nothing after.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -27,7 +27,9 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `seed/workflows/backlog-expiry.yml` → `.github/workflows/backlog-expiry.yml`,
    `seed/pull_request_template.md` → `.github/pull_request_template.md`,
    `seed/ISSUE_TEMPLATE/unit.yml` → `.github/ISSUE_TEMPLATE/unit.yml`,
-   `seed/scripts/merge_dev.py` → `scripts/merge_dev.py`.
+   `seed/ISSUE_TEMPLATE/config.yml` → `.github/ISSUE_TEMPLATE/config.yml`,
+   `seed/scripts/merge_dev.py` → `scripts/merge_dev.py` (align its
+   `REQUIRED_CHECKS` with the workload ci.yml's job names).
    Fill every `{{PLACEHOLDER}}` from the charter and design record. The
    copy is a divorce: this repo owes sofa-claude nothing after.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -5,8 +5,9 @@ description: Start-of-session orientation — one cheap read of the standing han
 
 # onboard
 
-1. Read the **body only** of Issue #1 (`gh issue view 1 --json body`). Never
-   read its comments — they are an append-only log, not live state.
+1. Read the **body only** of Issue #1 (`gh issue view 1 --json body`). The
+   body is the whole handoff — GitHub's edit history preserves prior
+   versions; there is no comment log.
 2. Sanity-check the body against `git log --oneline -10` on `main` and the
    open-PR list. If the handoff predates visible activity, say so — treat
    the repo and GitHub as truth, the handoff as a pointer.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,6 +52,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: CLAUDE.md stays under its 75-line budget
         run: |
-          n=$(wc -l < CLAUDE.md)
-          echo "CLAUDE.md: $n lines (max 74)"
-          [ "$n" -le 74 ]
+          n=$(wc -l < CLAUDE.md); c=$(wc -c < CLAUDE.md)
+          echo "CLAUDE.md: $n lines (max 74), $c chars (max 4200)"
+          [ "$n" -le 74 ] && [ "$c" -le 4200 ]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,3 +45,13 @@ jobs:
           else
             echo "No tests in this repo yet — nothing to run."
           fi
+
+  line-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CLAUDE.md stays under its 75-line budget
+        run: |
+          n=$(wc -l < CLAUDE.md)
+          echo "CLAUDE.md: $n lines (max 74)"
+          [ "$n" -le 74 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ only); `/wrap-up` before ending one (refreshes Issues #1 and #2).
 
 ## Rulebook budget
 
-This file stays under 75 lines. Adding a rule means removing or merging one.
+This file stays under 75 lines (CI-enforced). A new rule removes or merges one.
 On conflict, this file is normative: decision records (`decisions/`, one
 page each) are dated rationale, never live rules. Grants (`governance/`)
 take effect only by Steve merging the PR that adds or amends them.

--- a/decisions/0005-determinism-pass.md
+++ b/decisions/0005-determinism-pass.md
@@ -1,0 +1,46 @@
+# 0005 — Determinism pass for the weak-model era
+
+**Status:** accepted (Steve, 2026-08-19) · **Amends:** the seed kit and
+delivery mechanics; extends 0001's loud-failure principle
+
+## Context
+
+Steve commissioned an analysis: where does correct behavior still rest on
+model instruction-following that a weaker model will fumble? Findings:
+the process repo's CI was advisory (a red check did not block merging);
+the rulebook's 75-line budget was enforced by counting (violated twice in
+one day, both caught by hand); the workload `dev` merge — the riskiest
+unattended moment — was governed by four distributed prose rules; and
+nothing made a unit's acceptance criteria structurally required. Also
+corrected: rulesets/branch protection are free on public repos only, so
+Issue #4's machine-account gates reach sofa-claude but not private
+workload repos — there, the deterministic stack is Vercel wiring plus a
+paved-path merge tool.
+
+## Decision
+
+Three levers, applied where outcomes are verifiable and never to judgment:
+
+- **Gates.** Steve enabled a `main` ruleset on sofa-claude: PRs required,
+  status checks (`why-this-change`, `secrets`, `tests`) must pass;
+  approvals deliberately 0 until the machine account exists (an author
+  cannot approve their own PR). A `line-budget` CI job now fails any PR
+  that pushes CLAUDE.md past 74 lines.
+- **Paved paths.** Workload `dev` merges happen only via
+  `scripts/merge_dev.py` (seed kit, tested at source): it refuses unless
+  CI is green, a `## Reviewer pass` comment exists, the base is `dev`,
+  the head is `claude/*`, and the PR isn't draft — one instruction
+  replacing four rules, `gh`-native underneath. Unit issues are filed via
+  a GitHub issue form that makes acceptance criteria required at
+  creation.
+- **Boundary.** Stakes tiers, triage, review content, promotion timing
+  stay judgment — mechanizing judgment is the legacy theater trap.
+
+## Consequences
+
+A weak model can no longer merge red, oversize the rulebook, file an
+AC-less unit, or merge a workload PR that skipped review — those failures
+became impossible rather than prohibited. Prose shrinks as gates land.
+After this PR merges, Steve adds `line-budget` to the ruleset's required
+checks (30 seconds). Issues #5 and #7 remain the next mechanizations,
+scheduled with the Grant 1 rails.

--- a/decisions/0005-determinism-pass.md
+++ b/decisions/0005-determinism-pass.md
@@ -26,21 +26,33 @@ Three levers, applied where outcomes are verifiable and never to judgment:
   approvals deliberately 0 until the machine account exists (an author
   cannot approve their own PR). A `line-budget` CI job now fails any PR
   that pushes CLAUDE.md past 74 lines.
-- **Paved paths.** Workload `dev` merges happen only via
-  `scripts/merge_dev.py` (seed kit, tested at source): it refuses unless
-  CI is green, a `## Reviewer pass` comment exists, the base is `dev`,
-  the head is `claude/*`, and the PR isn't draft — one instruction
-  replacing four rules, `gh`-native underneath. Unit issues are filed via
-  a GitHub issue form that makes acceptance criteria required at
-  creation.
+- **Paved paths — honestly classified after this PR's own doc-review.**
+  Workload `dev` merges go via `scripts/merge_dev.py` (seed kit, tested
+  at source): it refuses unless every *named required check* succeeded
+  (absent is not green; skipped is not green for required checks), a
+  fresh-context reviewer comment *starting* with the marker exists (and
+  no refusal text can double as the credential), the base is `dev`, the
+  head is `claude/*`, and the PR isn't draft. Transport failures are loud
+  and explicitly forbid the by-hand workaround. This is a **paved path,
+  not a wall**: on free private repos nothing stops a raw `gh pr merge`,
+  so the rule "merging any other way is a defect" remains
+  instruction-backed — named here so nobody mistakes it for enforced.
+  Unit issues: the web form requires acceptance criteria and blank issues
+  are disabled, but `gh`-filed issues bypass forms — the form is a
+  web-path guardrail; the gh path remains instruction-backed.
 - **Boundary.** Stakes tiers, triage, review content, promotion timing
   stay judgment — mechanizing judgment is the legacy theater trap.
 
 ## Consequences
 
-A weak model can no longer merge red, oversize the rulebook, file an
-AC-less unit, or merge a workload PR that skipped review — those failures
-became impossible rather than prohibited. Prose shrinks as gates land.
-After this PR merges, Steve adds `line-budget` to the ruleset's required
-checks (30 seconds). Issues #5 and #7 remain the next mechanizations,
-scheduled with the Grant 1 rails.
+On sofa-claude, merging red or oversizing the rulebook became impossible
+(ruleset + `line-budget`, which caps characters as well as lines so
+rule-joining can't dodge it). On workload repos, the riskiest moments
+became one-instruction paved paths with loud refusals — materially
+harder to get wrong, but still instruction-backed at the edges named
+above. Residual bypasses are recorded, not denied: raw `gh pr merge`,
+`gh`-filed AC-less units, a self-posted reviewer marker, and the stale
+reviewer credential (Issue #10, `keep`). After this PR merges, Steve
+adds `line-budget` to the ruleset's required checks (30 seconds).
+Issues #5, #7, and #10 are the next mechanizations, scheduled with the
+Grant 1 rails.

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -13,7 +13,8 @@ bootstrap {{DATE}}; this repo owes it nothing).
   merges **only via `python3 scripts/merge_dev.py <PR>`**, which refuses
   unless CI is green, a fresh-context reviewer pass (one round, scaled to
   the charter's stakes tier) is posted as a PR comment starting
-  `## Reviewer pass`, the base is `dev`, and the PR isn't a draft. `dev`
+  `## Reviewer pass`, the base is `dev`, and the PR isn't a draft.
+  Merging any other way is a defect, not a shortcut. `dev`
   is the repo's default branch, so unit issues auto-close on merge. Open
   every PR at the first push, draft while review and fixes are in
   progress; ready means merging is the only step left.
@@ -27,9 +28,10 @@ bootstrap {{DATE}}; this repo owes it nothing).
 
 ## Units of work
 
-- One issue per unit, filed with the **Unit issue form** (it makes
-  acceptance criteria required at creation); criteria are frozen before
-  code. Done = merged to `dev`. No unit reopens; follow-ups are new intake.
+- One issue per unit, filed with the **Unit issue form** (the web form
+  requires acceptance criteria; a `gh`-filed unit must carry the same
+  sections); criteria are frozen before code. Done = merged to `dev`.
+  No unit reopens; follow-ups are new intake.
 - TDD: failing test first, then code. CI enforces the coverage floor of
   {{COVERAGE_FLOOR}}% — a floor to hold, never a number to climb.
 - Discovered work, first triage: fix in flight only what blocks the unit or

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -9,13 +9,14 @@ bootstrap {{DATE}}; this repo owes it nothing).
 
 ## Branches and deploys
 
-- `dev` — Claude's trunk. Feature branches `claude/*` PR into `dev`; Claude
-  merges at will once CI is green and a fresh-context reviewer pass — one
-  round, scaled to the charter's stakes tier — is posted as a comment on
-  the PR (no comment, no merge). `dev` is the repo's default branch, so
-  unit issues auto-close on merge. Open every PR at the first push, draft
-  while review and fixes are in progress; ready means merging is the only
-  step left.
+- `dev` — Claude's trunk. Feature branches `claude/*` PR into `dev`. Claude
+  merges **only via `python3 scripts/merge_dev.py <PR>`**, which refuses
+  unless CI is green, a fresh-context reviewer pass (one round, scaled to
+  the charter's stakes tier) is posted as a PR comment starting
+  `## Reviewer pass`, the base is `dev`, and the PR isn't a draft. `dev`
+  is the repo's default branch, so unit issues auto-close on merge. Open
+  every PR at the first push, draft while review and fixes are in
+  progress; ready means merging is the only step left.
 - `staging` — human-facing preview. Steve promotes `dev → staging` via a
   promotion PR that Claude prepares with a plain summary. {{VERCEL_PREVIEW}}
 - `main` — production. Steve promotes `staging → main`. {{VERCEL_PROD}}
@@ -26,8 +27,9 @@ bootstrap {{DATE}}; this repo owes it nothing).
 
 ## Units of work
 
-- One issue per unit; acceptance criteria frozen on the issue before code.
-  Done = merged to `dev`. No unit reopens; follow-ups are new intake.
+- One issue per unit, filed with the **Unit issue form** (it makes
+  acceptance criteria required at creation); criteria are frozen before
+  code. Done = merged to `dev`. No unit reopens; follow-ups are new intake.
 - TDD: failing test first, then code. CI enforces the coverage floor of
   {{COVERAGE_FLOOR}}% — a floor to hold, never a number to climb.
 - Discovered work, first triage: fix in flight only what blocks the unit or

--- a/seed/ISSUE_TEMPLATE/config.yml
+++ b/seed/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# Copied to .github/ISSUE_TEMPLATE/config.yml at bootstrap.
+blank_issues_enabled: false

--- a/seed/ISSUE_TEMPLATE/unit.yml
+++ b/seed/ISSUE_TEMPLATE/unit.yml
@@ -1,6 +1,7 @@
-# Copied to .github/ISSUE_TEMPLATE/unit.yml at bootstrap. The form makes
-# acceptance criteria structurally required — a unit cannot be filed
-# without them.
+# Copied to .github/ISSUE_TEMPLATE/unit.yml at bootstrap. The web form
+# requires acceptance criteria at creation; an issue filed via `gh` must
+# carry the same sections by rule — the form is a guardrail for the web
+# path, not a universal gate.
 name: Unit
 description: One unit of work — acceptance criteria are frozen here before any code.
 title: "Unit: "

--- a/seed/ISSUE_TEMPLATE/unit.yml
+++ b/seed/ISSUE_TEMPLATE/unit.yml
@@ -1,0 +1,25 @@
+# Copied to .github/ISSUE_TEMPLATE/unit.yml at bootstrap. The form makes
+# acceptance criteria structurally required — a unit cannot be filed
+# without them.
+name: Unit
+description: One unit of work — acceptance criteria are frozen here before any code.
+title: "Unit: "
+body:
+  - type: textarea
+    id: what-why
+    attributes:
+      label: What and why
+      description: What this unit delivers, and why it matters to the charter.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        Frozen once work starts. Each criterion must be testable; the unit
+        is done when all pass and the PR merges to dev. Discoveries during
+        the work follow the intake rule — they do not widen these criteria.
+      placeholder: "- [ ] ..."
+    validations:
+      required: true

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""The one way a workload PR merges to dev.
+"""The paved path for merging a workload PR to dev.
 
-Checks everything the process requires and refuses loudly otherwise, so a
-session needs to remember one instruction ("merge via this script"), not
-four rules. Uses `gh` for all transport.
+One instruction replaces four rules: this script refuses unless every
+required CI check succeeded, a fresh-context reviewer pass is posted, the
+base is dev, the head is claude/*, and the PR isn't a draft. It is a
+paved path, not a wall — nothing stops `gh pr merge` by hand, which is
+why merging any other way is declared a defect in CLAUDE.md.
+
+On transport failure it says so and stops: do NOT merge by hand as a
+workaround — fix the cause or put it in the needs-Steve digest.
 
 Usage: python3 scripts/merge_dev.py <PR-number>
 """
@@ -13,11 +18,19 @@ import subprocess
 import sys
 
 REVIEW_MARKER = "## Reviewer pass"
+# Bootstrap aligns these with the workload ci.yml's actual job names.
+REQUIRED_CHECKS = ("lint", "test", "secrets")
+# Acceptable states for checks that are NOT required (required checks
+# must be SUCCESS outright — a skipped required check is not green).
 GOOD_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 
 
 def evaluate(pr, comment_bodies):
-    """Return the list of blockers; empty means the merge may proceed."""
+    """Return the list of blockers; empty means the merge may proceed.
+
+    Invariant: no blocker string may contain REVIEW_MARKER, so a refusal
+    pasted into a PR comment can never become the passing credential.
+    """
     blockers = []
     if pr.get("isDraft"):
         blockers.append("PR is a draft — ready means merging is the only "
@@ -31,20 +44,28 @@ def evaluate(pr, comment_bodies):
     if not str(pr.get("headRefName", "")).startswith("claude/"):
         blockers.append(f"Head branch {pr.get('headRefName')!r} is not a "
                         "claude/* branch.")
-    checks = pr.get("statusCheckRollup") or []
-    if not checks:
-        blockers.append("No CI checks reported on this PR — green CI is "
-                        "required, and absent is not green.")
-    else:
-        bad = [c.get("name") or c.get("context") or "?" for c in checks
-               if (c.get("conclusion") or c.get("state") or "").upper()
-               not in GOOD_CONCLUSIONS]
-        if bad:
-            blockers.append("CI not green: " + ", ".join(sorted(bad)))
-    if not any(REVIEW_MARKER in (body or "") for body in comment_bodies):
-        blockers.append(f"No reviewer-pass comment found (a PR comment "
-                        f"starting {REVIEW_MARKER!r} is required — no "
-                        "comment, no merge).")
+    statuses = {}
+    for c in pr.get("statusCheckRollup") or []:
+        name = c.get("name") or c.get("context") or "?"
+        statuses[name] = (c.get("conclusion") or c.get("state") or "").upper()
+    for req in REQUIRED_CHECKS:
+        if req not in statuses:
+            blockers.append(f"Required check {req!r} is absent — absent is "
+                            "not green.")
+        elif statuses[req] != "SUCCESS":
+            blockers.append(f"Required check {req!r} is "
+                            f"{statuses[req] or 'UNKNOWN'}, not SUCCESS.")
+    bad_others = sorted(n for n, s in statuses.items()
+                        if n not in REQUIRED_CHECKS
+                        and s not in GOOD_CONCLUSIONS)
+    if bad_others:
+        blockers.append("Failing checks: " + ", ".join(bad_others))
+    if not any((body or "").lstrip().startswith(REVIEW_MARKER)
+               for body in comment_bodies):
+        blockers.append("No reviewer-pass comment found — a fresh-context "
+                        "reviewer must post one, with the marker heading "
+                        "on its first line (see CLAUDE.md). No comment, "
+                        "no merge.")
     return blockers
 
 
@@ -53,14 +74,27 @@ def _gh(args):
                           text=True).stdout
 
 
+def _transport_failure(err):
+    print("TRANSPORT FAILURE — nothing was merged.")
+    detail = (getattr(err, "stderr", "") or "").strip()
+    if detail:
+        print(detail)
+    print("Do NOT merge by hand as a workaround — fix the cause or put "
+          "it in the needs-Steve digest.")
+    return 3
+
+
 def main(argv):
     if len(argv) != 2 or not argv[1].isdigit():
         print(__doc__)
         return 2
     number = argv[1]
-    pr = json.loads(_gh(["pr", "view", number, "--json",
-                         "isDraft,state,baseRefName,headRefName,"
-                         "statusCheckRollup,comments"]))
+    try:
+        pr = json.loads(_gh(["pr", "view", number, "--json",
+                             "isDraft,state,baseRefName,headRefName,"
+                             "statusCheckRollup,comments"]))
+    except subprocess.CalledProcessError as err:
+        return _transport_failure(err)
     bodies = [c.get("body", "") for c in pr.get("comments") or []]
     blockers = evaluate(pr, bodies)
     if blockers:
@@ -68,7 +102,10 @@ def main(argv):
         for b in blockers:
             print(f"  - {b}")
         return 1
-    _gh(["pr", "merge", number, "--squash", "--delete-branch"])
+    try:
+        _gh(["pr", "merge", number, "--squash", "--delete-branch"])
+    except subprocess.CalledProcessError as err:
+        return _transport_failure(err)
     print(f"Merged PR #{number} to dev (squash) and deleted its branch.")
     return 0
 

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The one way a workload PR merges to dev.
+
+Checks everything the process requires and refuses loudly otherwise, so a
+session needs to remember one instruction ("merge via this script"), not
+four rules. Uses `gh` for all transport.
+
+Usage: python3 scripts/merge_dev.py <PR-number>
+"""
+
+import json
+import subprocess
+import sys
+
+REVIEW_MARKER = "## Reviewer pass"
+GOOD_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+
+
+def evaluate(pr, comment_bodies):
+    """Return the list of blockers; empty means the merge may proceed."""
+    blockers = []
+    if pr.get("isDraft"):
+        blockers.append("PR is a draft — ready means merging is the only "
+                        "step left, and this PR isn't there yet.")
+    if pr.get("state") != "OPEN":
+        blockers.append(f"PR state is {pr.get('state')!r}, not OPEN.")
+    if pr.get("baseRefName") != "dev":
+        blockers.append(f"Base branch is {pr.get('baseRefName')!r} — this "
+                        "script merges to dev only; staging and main are "
+                        "Steve's promotions.")
+    if not str(pr.get("headRefName", "")).startswith("claude/"):
+        blockers.append(f"Head branch {pr.get('headRefName')!r} is not a "
+                        "claude/* branch.")
+    checks = pr.get("statusCheckRollup") or []
+    if not checks:
+        blockers.append("No CI checks reported on this PR — green CI is "
+                        "required, and absent is not green.")
+    else:
+        bad = [c.get("name") or c.get("context") or "?" for c in checks
+               if (c.get("conclusion") or c.get("state") or "").upper()
+               not in GOOD_CONCLUSIONS]
+        if bad:
+            blockers.append("CI not green: " + ", ".join(sorted(bad)))
+    if not any(REVIEW_MARKER in (body or "") for body in comment_bodies):
+        blockers.append(f"No reviewer-pass comment found (a PR comment "
+                        f"starting {REVIEW_MARKER!r} is required — no "
+                        "comment, no merge).")
+    return blockers
+
+
+def _gh(args):
+    return subprocess.run(["gh"] + args, check=True, capture_output=True,
+                          text=True).stdout
+
+
+def main(argv):
+    if len(argv) != 2 or not argv[1].isdigit():
+        print(__doc__)
+        return 2
+    number = argv[1]
+    pr = json.loads(_gh(["pr", "view", number, "--json",
+                         "isDraft,state,baseRefName,headRefName,"
+                         "statusCheckRollup,comments"]))
+    bodies = [c.get("body", "") for c in pr.get("comments") or []]
+    blockers = evaluate(pr, bodies)
+    if blockers:
+        print(f"REFUSED — PR #{number} is not mergeable to dev:")
+        for b in blockers:
+            print(f"  - {b}")
+        return 1
+    _gh(["pr", "merge", number, "--squash", "--delete-branch"])
+    print(f"Merged PR #{number} to dev (squash) and deleted its branch.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -1,0 +1,76 @@
+"""Tests for the seed kit's paved-path merge script's decision logic."""
+
+import importlib.util
+import pathlib
+import unittest
+
+_path = pathlib.Path(__file__).resolve().parent.parent / "seed" / "scripts" / "merge_dev.py"
+_spec = importlib.util.spec_from_file_location("merge_dev", _path)
+merge_dev = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(merge_dev)
+
+REVIEW = f"{merge_dev.REVIEW_MARKER}\nLooks correct; one keep-grade note filed."
+
+
+def pr(**over):
+    base = {
+        "isDraft": False,
+        "state": "OPEN",
+        "baseRefName": "dev",
+        "headRefName": "claude/unit-1",
+        "statusCheckRollup": [{"name": "ci", "conclusion": "SUCCESS"}],
+    }
+    base.update(over)
+    return base
+
+
+class EvaluateTests(unittest.TestCase):
+    def test_happy_path_has_no_blockers(self):
+        self.assertEqual(merge_dev.evaluate(pr(), [REVIEW]), [])
+
+    def test_draft_blocks(self):
+        self.assertTrue(any("draft" in b for b in
+                            merge_dev.evaluate(pr(isDraft=True), [REVIEW])))
+
+    def test_closed_state_blocks(self):
+        self.assertTrue(any("OPEN" in b for b in
+                            merge_dev.evaluate(pr(state="MERGED"), [REVIEW])))
+
+    def test_wrong_base_blocks(self):
+        blockers = merge_dev.evaluate(pr(baseRefName="main"), [REVIEW])
+        self.assertTrue(any("dev only" in b for b in blockers))
+
+    def test_non_claude_head_blocks(self):
+        blockers = merge_dev.evaluate(pr(headRefName="fix-1"), [REVIEW])
+        self.assertTrue(any("claude/*" in b for b in blockers))
+
+    def test_no_checks_is_not_green(self):
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=[]), [REVIEW])
+        self.assertTrue(any("absent is not green" in b for b in blockers))
+
+    def test_failed_check_blocks_and_is_named(self):
+        rollup = [{"name": "ci", "conclusion": "SUCCESS"},
+                  {"name": "coverage", "conclusion": "FAILURE"}]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("coverage" in b for b in blockers))
+
+    def test_pending_check_blocks(self):
+        rollup = [{"name": "ci", "state": "PENDING"}]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("CI not green" in b for b in blockers))
+
+    def test_missing_review_comment_blocks(self):
+        blockers = merge_dev.evaluate(pr(), ["lgtm!"])
+        self.assertTrue(any("no merge" in b for b in blockers))
+
+    def test_review_marker_anywhere_in_comments_passes(self):
+        self.assertEqual(merge_dev.evaluate(pr(), ["chatter", REVIEW]), [])
+
+    def test_multiple_blockers_all_reported(self):
+        blockers = merge_dev.evaluate(
+            pr(isDraft=True, baseRefName="staging", statusCheckRollup=[]), [])
+        self.assertEqual(len(blockers), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -2,7 +2,9 @@
 
 import importlib.util
 import pathlib
+import subprocess
 import unittest
+from unittest import mock
 
 _path = pathlib.Path(__file__).resolve().parent.parent / "seed" / "scripts" / "merge_dev.py"
 _spec = importlib.util.spec_from_file_location("merge_dev", _path)
@@ -10,6 +12,7 @@ merge_dev = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(merge_dev)
 
 REVIEW = f"{merge_dev.REVIEW_MARKER}\nLooks correct; one keep-grade note filed."
+GREEN = [{"name": n, "conclusion": "SUCCESS"} for n in merge_dev.REQUIRED_CHECKS]
 
 
 def pr(**over):
@@ -18,7 +21,7 @@ def pr(**over):
         "state": "OPEN",
         "baseRefName": "dev",
         "headRefName": "claude/unit-1",
-        "statusCheckRollup": [{"name": "ci", "conclusion": "SUCCESS"}],
+        "statusCheckRollup": list(GREEN),
     }
     base.update(over)
     return base
@@ -44,32 +47,59 @@ class EvaluateTests(unittest.TestCase):
         blockers = merge_dev.evaluate(pr(headRefName="fix-1"), [REVIEW])
         self.assertTrue(any("claude/*" in b for b in blockers))
 
-    def test_no_checks_is_not_green(self):
-        blockers = merge_dev.evaluate(pr(statusCheckRollup=[]), [REVIEW])
-        self.assertTrue(any("absent is not green" in b for b in blockers))
+    def test_missing_required_check_blocks(self):
+        rollup = [c for c in GREEN if c["name"] != "secrets"]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("'secrets'" in b and "absent is not green" in b
+                            for b in blockers))
 
-    def test_failed_check_blocks_and_is_named(self):
-        rollup = [{"name": "ci", "conclusion": "SUCCESS"},
-                  {"name": "coverage", "conclusion": "FAILURE"}]
+    def test_skipped_required_check_blocks(self):
+        rollup = [c for c in GREEN if c["name"] != "test"]
+        rollup.append({"name": "test", "conclusion": "SKIPPED"})
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("'test'" in b and "SKIPPED" in b for b in blockers))
+
+    def test_vercel_status_alone_is_not_green(self):
+        rollup = [{"context": "vercel", "state": "SUCCESS"}]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertEqual(len([b for b in blockers if "absent" in b]),
+                         len(merge_dev.REQUIRED_CHECKS))
+
+    def test_failing_non_required_check_is_named(self):
+        rollup = list(GREEN) + [{"name": "coverage", "conclusion": "FAILURE"}]
         blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
         self.assertTrue(any("coverage" in b for b in blockers))
 
-    def test_pending_check_blocks(self):
-        rollup = [{"name": "ci", "state": "PENDING"}]
-        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
-        self.assertTrue(any("CI not green" in b for b in blockers))
-
-    def test_missing_review_comment_blocks(self):
-        blockers = merge_dev.evaluate(pr(), ["lgtm!"])
+    def test_marker_must_start_the_comment(self):
+        mid = f"as discussed, {merge_dev.REVIEW_MARKER} was posted earlier"
+        blockers = merge_dev.evaluate(pr(), [mid])
         self.assertTrue(any("no merge" in b for b in blockers))
+        self.assertEqual(merge_dev.evaluate(pr(), ["  \n" + REVIEW]), [])
 
-    def test_review_marker_anywhere_in_comments_passes(self):
-        self.assertEqual(merge_dev.evaluate(pr(), ["chatter", REVIEW]), [])
+    def test_refusal_text_never_contains_the_marker(self):
+        blockers = merge_dev.evaluate(
+            pr(isDraft=True, state="CLOSED", baseRefName="main",
+               headRefName="x", statusCheckRollup=[]), ["nope"])
+        self.assertTrue(blockers)
+        self.assertFalse(any(merge_dev.REVIEW_MARKER in b for b in blockers))
 
     def test_multiple_blockers_all_reported(self):
+        # draft + wrong base + 3 absent required checks + no marker = 6
         blockers = merge_dev.evaluate(
             pr(isDraft=True, baseRefName="staging", statusCheckRollup=[]), [])
-        self.assertEqual(len(blockers), 4)
+        self.assertEqual(len(blockers), 6)
+
+
+class TransportTests(unittest.TestCase):
+    def test_transport_failure_is_loud_and_does_not_merge(self):
+        err = subprocess.CalledProcessError(1, ["gh"], stderr="boom")
+        with mock.patch.object(merge_dev, "_gh", side_effect=err):
+            with mock.patch("builtins.print") as fake_print:
+                self.assertEqual(merge_dev.main(["merge_dev.py", "12"]), 3)
+        printed = " ".join(str(c.args[0]) for c in fake_print.call_args_list)
+        self.assertIn("TRANSPORT FAILURE", printed)
+        self.assertIn("boom", printed)
+        self.assertIn("Do NOT merge by hand", printed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why this change

Steve commissioned a determinism analysis for the weak-model era (2026-08-19): correct behavior rested on instruction-following in four places where it could be structural instead — the process repo's CI was advisory until today's ruleset, the 75-line rulebook budget was enforced by counting (violated twice in one day, caught by hand both times), the workload `dev` merge was four distributed prose rules, and nothing made acceptance criteria structurally required. Rationale: [decisions/0005](https://github.com/smansf/sofa-claude/blob/claude/determinism-pass/decisions/0005-determinism-pass.md).

**Fix round (doc-review, 7 findings — comment below):** required-checks list with absent-is-not-green semantics; reviewer marker must start the comment and refusal text can never double as the credential; transport failures loud with an explicit no-by-hand-merge instruction; character cap beside the line cap; blank issues disabled; and — the big one — decisions/0005 reclassified honestly: the script and form are paved paths, not walls, with every residual bypass named instead of denied. Finding 5 filed as Issue #10 (`keep`). Also folds Issue #8's one-line onboard fix. Closes #8.

## What changed

- **`line-budget` CI job**: fails any PR pushing CLAUDE.md past 74 lines. (After merge: add `line-budget` to the `protect-main` ruleset's required checks — 30 seconds.)
- **`seed/scripts/merge_dev.py`** + tests: the one way a workload PR merges to `dev` — refuses unless CI is green, a `## Reviewer pass` comment exists, base is `dev`, head is `claude/*`, and the PR isn't draft. One instruction replaces four rules; `gh`-native transport; decision logic unit-tested at source (11 tests).
- **`seed/ISSUE_TEMPLATE/unit.yml`**: GitHub issue form making acceptance criteria required at unit creation.
- Seed CLAUDE.md template and bootstrap copy-list updated accordingly; rulebook line reworded to "(CI-enforced)" at constant length; decisions/0005 records the analysis, including the correction that rulesets don't reach free private workload repos (there the stack is Vercel wiring + this merge script).

## Verification

`python3 -m unittest discover -s tests -v` — 11 tests, all passing (run below and in this PR's CI, whose `tests` job now exercises the script's decision logic). The `line-budget` job runs green on this PR against the 74-line CLAUDE.md. Seam artifact: doc-review findings comment to follow; `/code-review` command will be in the digest.
