### PR TITLE
Seed: draft-until-Steve promotion PRs, record zero-finding reviews

### DIFF
--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -19,7 +19,12 @@ bootstrap {{DATE}}; this repo owes it nothing).
   every PR at the first push, draft while review and fixes are in
   progress; ready means merging is the only step left.
 - `staging` — human-facing preview. Steve promotes `dev → staging` via a
-  promotion PR that Claude prepares with a plain summary. {{VERCEL_PREVIEW}}
+  promotion PR that Claude prepares with a plain summary. Promotion PRs
+  **open as draft**; Steve flips ready (or merges directly) after
+  spending whatever review depth he chooses — ready means Steve has
+  decided, in every lane. A zero-finding run of his review lane is
+  recorded as a PR comment, so a clean review leaves the same durable
+  trace a finding would. {{VERCEL_PREVIEW}}
 - `main` — production. Steve promotes `staging → main`. {{VERCEL_PROD}}
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -20,11 +20,16 @@ bootstrap {{DATE}}; this repo owes it nothing).
   progress; ready means merging is the only step left.
 - `staging` — human-facing preview. Steve promotes `dev → staging` via a
   promotion PR that Claude prepares with a plain summary. Promotion PRs
-  **open as draft**; Steve flips ready (or merges directly) after
-  spending whatever review depth he chooses — ready means Steve has
-  decided, in every lane. A zero-finding run of his review lane is
-  recorded as a PR comment, so a clean review leaves the same durable
-  trace a finding would. {{VERCEL_PREVIEW}}
+  **open as draft** (`gh pr create --draft` — opening one ready is a
+  defect, not a shortcut). Steve flips ready and merges after spending
+  whatever review depth he chooses; Claude never flips a promotion PR
+  to ready, so for promotion PRs the ready flip is itself the record
+  that Steve decided — review run or skipped. When his review lane
+  returns zero findings, the session that observed the run records that
+  outcome as a PR comment quoting the tool's summary — an observed
+  result, never an invocation or replication of his lane; absent both
+  findings and a record comment, the review is treated as not yet
+  run. {{VERCEL_PREVIEW}}
 - `main` — production. Steve promotes `staging → main`. {{VERCEL_PROD}}
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
@@ -51,7 +56,7 @@ bootstrap {{DATE}}; this repo owes it nothing).
   toolbox); at production stakes Steve re-approves via PR review.
   Promotion PRs hand Steve the paste-ready
   `/code-review <effort> <PR URL> --comment` command and confirm its
-  findings actually landed on the PR.
+  findings — or the zero-finding record — actually landed on the PR.
 
 ## Never
 


### PR DESCRIPTION
## Why this change

Concrete incident, sofa-scratch trial (2026-08-20): promotion PR #33 was marked ready before Steve's review lane had run — a green, ready-looking PR invites an autopilot merge, quietly demoting his review from gate to ornament; and when his `/code-review low` then ran with zero findings, `--comment` posted nothing, leaving no durable trace that the lane ran at all — colliding with the process's own no-comment-no-review doctrine. Steve set both conventions in chat; sofa-scratch's CLAUDE.md is being amended in its own PR (sofa-scratch PR #34); this PR fixes the seed so future workloads inherit them.

## What changed

The staging bullet in `seed/CLAUDE.md.template` now states: promotion PRs open as draft and Steve flips ready (or merges directly) after choosing his review depth — ready means Steve has decided, uniformly across lanes; and a zero-finding run of his review lane is recorded as a PR comment.

## Verification

Prose-only template change; CI checks (why-this-change, secrets, tests, line-budget) must be green. The convention is exercised live by sofa-scratch's next promotion PR.

Code-review lane (Steve's to type): `/code-review low https://github.com/smansf/sofa-claude/pull/15 --comment` — doc-review lane runs below per the seam rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEkUnEsbcWqSkCytitRE7P