### PR TITLE
Harvest six seed defects from the sofa-scratch bootstrap

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -10,9 +10,12 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
 1. **Charter first** (`docs/charter.md`, one page, elicited from Steve):
    what is being built and why; who uses it; the **stakes tier**
    (throwaway / standard / production) that sets review depth everywhere;
-   the coverage floor; and the project's **end condition** — what done
-   looks like, written before work starts and *falsifiable*: if you can't
-   say how you'd test that it's met, rewrite it until you can.
+   the **test floor**, in whatever shape the subject actually has — a
+   coverage percentage, fixture-corpus completeness, a property suite —
+   which must be mechanically checkable by CI, because a shape that forces
+   a fake number is the wrong shape; and the project's **end condition**
+   — what done looks like, written before work starts and *falsifiable*:
+   if you can't say how you'd test that it's met, rewrite it until you can.
 2. **Design record — scaled by the stakes tier.** Throwaway: skip
    entirely; the charter is enough. Standard and production: one page
    (`docs/design.md`) — stack choice and why, architecture sketch, data
@@ -29,7 +32,12 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `seed/ISSUE_TEMPLATE/unit.yml` → `.github/ISSUE_TEMPLATE/unit.yml`,
    `seed/ISSUE_TEMPLATE/config.yml` → `.github/ISSUE_TEMPLATE/config.yml`,
    `seed/scripts/merge_dev.py` → `scripts/merge_dev.py` (align its
-   `REQUIRED_CHECKS` with the workload ci.yml's job names).
+   `REQUIRED_CHECKS` with the workload ci.yml's job names, and keep its
+   executable bit — a copy that drops it fails lint on the seed's own
+   file),
+   `seed/gitignore` → `.gitignore` (extend for the stack; without it the
+   first `git add -A` after a test run can commit bytecode that has secret
+   fixtures folded into it).
    Fill every `{{PLACEHOLDER}}` from the charter and design record. The
    copy is a divorce: this repo owes sofa-claude nothing after.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
@@ -38,6 +46,14 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    it in the needs-Steve digest, because unit auto-close and the expiry
    record both silently lie until it's fixed). Unit issues then auto-close
    when their PR merges to `dev`, and new PRs target `dev` by default.
+   **Disable "automatically delete head branches"**
+   (`gh repo edit --delete-branch-on-merge=false`, then confirm with
+   `gh repo view --json deleteBranchOnMerge`): a promotion PR's head *is*
+   a long-lived branch, so the setting deletes `staging` the first time
+   Steve promotes to `main`, and `merge_dev.py` already deletes unit
+   branches itself. If the edit doesn't stick, it goes in the needs-Steve
+   digest and **the repo does not promote until it is off, or the
+   `staging`/`main` ruleset exists** — protected branches are exempt.
    Create labels `urgent`, `keep`,
    `standing`; create the standing handoff issue **labeled `standing`**
    (unlabeled, the repo's own expiry workflow will close it) and note its
@@ -55,11 +71,13 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    every item steps 3–4 claimed: default branch is `dev`; `staging`
    exists; labels `urgent`, `keep`, `standing` exist; `ci.yml`,
    `backlog-expiry.yml`, `pull_request_template.md`, both issue templates
-   (`config.yml` with `blank_issues_enabled: false`), and
+   (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
-   names) are all present; the standing handoff issue exists, carries
-   `standing`, and CLAUDE.md names its number. A failed check that one
-   `gh` command repairs is re-run once, re-verified, and noted in the
+   names, its executable bit intact) are all present;
+   `deleteBranchOnMerge` is false, or `staging` and `main` are protected;
+   the standing handoff issue exists, carries `standing`, and CLAUDE.md
+   names its number. A failed check that one `gh` command repairs is
+   re-run once, re-verified, and noted in the
    bootstrap PR — repaired loudly, never silently. What still fails gets
    filed in the new repo, labeled by the seeded triage doctrine —
    `urgent` when it invalidates the first unit's premise, else `keep`;

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -46,10 +46,13 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    is collected, and that is correct — a `test` job that ran no tests is
    not a passing `test` job, and a CI branch that reports SUCCESS having
    run nothing is the legacy failure (0005) rebuilt inside the test gate.
-   The default that always works: a test asserting `docs/charter.md`
-   states an end condition and the test floor, which is a real invariant
-   that really breaks. Fill `{{TEST_COMMAND_WITH_FLOOR}}` so it exercises
-   it.
+   Ship the smallest real module the charter implies — the CLI entry
+   point, the one exported function — plus a test covering it. A charter
+   assertion test alone is not enough when the floor is a coverage
+   percentage: `--cov-fail-under` against a repo with no product code
+   reports no data and fails, which is defect 2 recurring one step later,
+   because the floor and the test run are the same command. Real module
+   plus real test satisfies every floor shape.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
    as the default branch, then verify it stuck** (`gh repo view --json
    defaultBranchRef` must say `dev` — if it doesn't, stop wiring and put
@@ -89,13 +92,15 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
    names, its executable bit intact) are all present;
-   **no seed placeholder survives** in any copied file — grep for
-   `{{[A-Z_]\+}}`, the seed's own placeholder shape, **not** a bare `{{`,
-   which would match the workflows' legitimate `${{ secrets.GITHUB_TOKEN }}`
-   and fail on every bootstrap forever; an unfilled placeholder is the seed
-   silently ceasing to be authoritative, which is the defect class this
-   step exists for. The `test` job ran a real command and the repo tracks
-   at least one test file. `deleteBranchOnMerge` is false, or the
+   **no seed placeholder survives** in any copied file — grep for `{{`
+   and discard only `${{` (GitHub Actions expressions, which are
+   legitimate and permanent). Do not narrow this to `{{[A-Z_]\+}}`: the
+   stakes tier is written `{{throwaway | standard | production}}` and
+   would slip through, leaving review depth read off an unfilled slot
+   forever. An unfilled placeholder is the seed silently ceasing to be
+   authoritative, which is the defect class this step exists for. The
+   `test` job ran a real command, and the repo tracks at least one test
+   file and the module it covers. `deleteBranchOnMerge` is false, or the
    needs-Steve digest carries it with the click path;
    the standing handoff issue exists, carries `standing`, and CLAUDE.md
    names its number. A failed check that one `gh` command repairs is

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -33,8 +33,9 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `seed/ISSUE_TEMPLATE/config.yml` → `.github/ISSUE_TEMPLATE/config.yml`,
    `seed/scripts/merge_dev.py` → `scripts/merge_dev.py` (align its
    `REQUIRED_CHECKS` with the workload ci.yml's job names, and keep its
-   executable bit — a copy that drops it fails lint on the seed's own
-   file),
+   executable bit — mode `100755`, so the shebang stays honest and a lint
+   config that enables EXE001 has nothing to flag; note ruff's defaults do
+   not, so nothing in a bootstrapped repo catches a dropped bit for you),
    `seed/gitignore` → `.gitignore` (extend for the stack; without it the
    first `git add -A` after a test run can commit bytecode that has secret
    fixtures folded into it).
@@ -51,13 +52,18 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `gh repo view --json deleteBranchOnMerge`): a promotion PR's head *is*
    a long-lived branch, so the setting deletes `staging` the first time
    Steve promotes to `main`, and `merge_dev.py` already deletes unit
-   branches itself. If the edit doesn't stick, it goes in the needs-Steve
-   digest and **the repo does not promote until it is off, or the
-   `staging`/`main` ruleset exists** — protected branches are exempt.
+   branches itself. **Expect this to 403** — repo administration is
+   outside the current token (sofa-claude Issue #14), so the normal
+   outcome is a needs-Steve digest entry with the exact click path
+   (Settings → General, ~15 s), not a repaired setting. Do not write it as
+   a standing bar the repo starts out violating: the seeded CLAUDE.md
+   carries the check at the moment it bites, holding the *first promotion*
+   until the setting is off. Branch protection also exempts a branch, but
+   is unavailable on private repos at this plan — never rely on it.
    Create labels `urgent`, `keep`,
    `standing`; create the standing handoff issue **labeled `standing`**
-   (unlabeled, the repo's own expiry workflow will close it) and note its
-   number in CLAUDE.md. Vercel wiring is Steve's step — list it in the needs-Steve
+   (unlabeled, the repo's own expiry workflow will close it) and fill
+   `{{HANDOFF_ISSUE}}` in CLAUDE.md with its number. Vercel wiring is Steve's step — list it in the needs-Steve
    digest, don't wait.
 5. **Propose the first unit**: one issue, frozen acceptance criteria,
    sized to reach `dev` within a session. Product code, not process — if
@@ -74,7 +80,11 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
    names, its executable bit intact) are all present;
-   `deleteBranchOnMerge` is false, or `staging` and `main` are protected;
+   **no `{{` placeholder marker survives** in any copied file (one grep
+   over the copies — an unfilled placeholder is the seed silently ceasing
+   to be authoritative, which is the whole defect class this step exists
+   for); `deleteBranchOnMerge` is false, or the needs-Steve digest carries
+   it with the click path;
    the standing handoff issue exists, carries `standing`, and CLAUDE.md
    names its number. A failed check that one `gh` command repairs is
    re-run once, re-verified, and noted in the

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -41,6 +41,15 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    fixtures folded into it).
    Fill every `{{PLACEHOLDER}}` from the charter and design record. The
    copy is a divorce: this repo owes sofa-claude nothing after.
+   **The bootstrap PR ships at least one real test**, because `ci.yml`
+   has no zero-test escape hatch: most runners exit non-zero when nothing
+   is collected, and that is correct — a `test` job that ran no tests is
+   not a passing `test` job, and a CI branch that reports SUCCESS having
+   run nothing is the legacy failure (0005) rebuilt inside the test gate.
+   The default that always works: a test asserting `docs/charter.md`
+   states an end condition and the test floor, which is a real invariant
+   that really breaks. Fill `{{TEST_COMMAND_WITH_FLOOR}}` so it exercises
+   it.
 4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
    as the default branch, then verify it stuck** (`gh repo view --json
    defaultBranchRef` must say `dev` — if it doesn't, stop wiring and put
@@ -63,8 +72,8 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    Create labels `urgent`, `keep`,
    `standing`; create the standing handoff issue **labeled `standing`**
    (unlabeled, the repo's own expiry workflow will close it) and fill
-   `{{HANDOFF_ISSUE}}` in CLAUDE.md with its number. Vercel wiring is Steve's step — list it in the needs-Steve
-   digest, don't wait.
+   `{{HANDOFF_ISSUE}}` in CLAUDE.md with its number. Vercel wiring is
+   Steve's step — list it in the needs-Steve digest, don't wait.
 5. **Propose the first unit**: one issue, frozen acceptance criteria,
    sized to reach `dev` within a session. Product code, not process — if
    the process pinches during the unit, that's a sofa-claude bleed to
@@ -80,11 +89,14 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
    names, its executable bit intact) are all present;
-   **no `{{` placeholder marker survives** in any copied file (one grep
-   over the copies — an unfilled placeholder is the seed silently ceasing
-   to be authoritative, which is the whole defect class this step exists
-   for); `deleteBranchOnMerge` is false, or the needs-Steve digest carries
-   it with the click path;
+   **no seed placeholder survives** in any copied file — grep for
+   `{{[A-Z_]\+}}`, the seed's own placeholder shape, **not** a bare `{{`,
+   which would match the workflows' legitimate `${{ secrets.GITHUB_TOKEN }}`
+   and fail on every bootstrap forever; an unfilled placeholder is the seed
+   silently ceasing to be authoritative, which is the defect class this
+   step exists for. The `test` job ran a real command and the repo tracks
+   at least one test file. `deleteBranchOnMerge` is false, or the
+   needs-Steve digest carries it with the click path;
    the standing handoff issue exists, carries `standing`, and CLAUDE.md
    names its number. A failed check that one `gh` command repairs is
    re-run once, re-verified, and noted in the

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -42,8 +42,12 @@ bootstrap {{DATE}}; this repo owes it nothing).
   requires acceptance criteria; a `gh`-filed unit must carry the same
   sections); criteria are frozen before code. Done = merged to `dev`.
   No unit reopens; follow-ups are new intake.
-- TDD: failing test first, then code. CI enforces the coverage floor of
-  {{COVERAGE_FLOOR}}% — a floor to hold, never a number to climb.
+- TDD: failing test first, then code. CI enforces the charter's **test
+  floor** — {{TEST_FLOOR}} — a floor to hold, never a number to climb. The
+  floor takes whatever shape the charter's subject actually has (a coverage
+  percentage, fixture-corpus completeness, a property suite); it must be
+  mechanically checkable by CI, and a shape that forces a fake number is the
+  wrong shape.
 - Discovered work, first triage: fix in flight only what blocks the unit or
   is a trivial defect in code already being touched (capped at trivial —
   wants design ⇒ file it). Everything else real is filed silently, at any

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -7,6 +7,9 @@ project's **stakes tier** ({{throwaway | standard | production}}), which sets
 review depth everywhere below. Process origin: smansf/sofa-claude (copied at
 bootstrap {{DATE}}; this repo owes it nothing).
 
+Standing handoff: Issue {{HANDOFF_ISSUE}} — `/onboard` reads it, `/wrap-up`
+refreshes it.
+
 ## Branches and deploys
 
 - `dev` — Claude's trunk. Feature branches `claude/*` PR into `dev`. Claude
@@ -31,6 +34,14 @@ bootstrap {{DATE}}; this repo owes it nothing).
   findings and a record comment, the review is treated as not yet
   run. {{VERCEL_PREVIEW}}
 - `main` — production. Steve promotes `staging → main`. {{VERCEL_PROD}}
+- **Before preparing the first promotion PR**, confirm `gh repo view --json
+  deleteBranchOnMerge` reports `false`. A promotion PR's head *is* a
+  long-lived branch, so with the setting on, merging `staging → main`
+  deletes `staging`. If it reports `true` the promotion waits: it is a
+  needs-Steve item (Settings → General, ~15 s), and `scripts/merge_dev.py`
+  already deletes unit branches itself, so nothing here needs the setting.
+  Protected `staging`/`main` are exempt, but branch protection is not
+  available on private repos at this plan — do not rely on it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
 - Promote often: a `dev` far ahead of `staging` makes promotion scary

--- a/seed/gitignore
+++ b/seed/gitignore
@@ -1,0 +1,18 @@
+# Copied to the workload repo's .gitignore at bootstrap. Kept minimal and
+# extended per stack — the point is that a repo is never one `git add -A`
+# away from committing build output. Compiled Python bytecode is the case
+# that bit us: it constant-folds split string literals, so a secret-shaped
+# test fixture that was never committed as source can land in history
+# inside a .pyc.
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+node_modules/
+dist/
+build/
+*.egg-info/
+.coverage
+htmlcov/
+.env
+.DS_Store

--- a/seed/gitignore
+++ b/seed/gitignore
@@ -11,6 +11,8 @@ venv/
 node_modules/
 dist/
 build/
+.next/
+.vercel/
 *.egg-info/
 .coverage
 htmlcov/

--- a/seed/gitignore
+++ b/seed/gitignore
@@ -15,4 +15,6 @@ build/
 .coverage
 htmlcov/
 .env
+.env.*
+!.env.example
 .DS_Store

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -90,9 +90,8 @@ def main(argv):
         return 2
     number = argv[1]
     try:
-        pr = json.loads(_gh(["pr", "view", number, "--json",
-                             "isDraft,state,baseRefName,headRefName,"
-                             "statusCheckRollup,comments"]))
+        fields = "isDraft,state,baseRefName,headRefName,statusCheckRollup,comments"
+        pr = json.loads(_gh(["pr", "view", number, "--json", fields]))
     except subprocess.CalledProcessError as err:
         return _transport_failure(err)
     bodies = [c.get("body", "") for c in pr.get("comments") or []]

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -90,7 +90,8 @@ def main(argv):
         return 2
     number = argv[1]
     try:
-        fields = "isDraft,state,baseRefName,headRefName,statusCheckRollup,comments"
+        fields = ("isDraft,state,baseRefName,headRefName,"
+                  "statusCheckRollup,comments")
         pr = json.loads(_gh(["pr", "view", number, "--json", fields]))
     except subprocess.CalledProcessError as err:
         return _transport_failure(err)

--- a/seed/workflows/ci.yml
+++ b/seed/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Seed CI for a workload repo. Bootstrap adapts the stack-specific parts
-# ({{...}} placeholders) to the project's actual language and tooling.
+# (the placeholder markers) to the project's actual language and tooling.
 name: ci
 
 # claude/* branches are deliberately absent from the push list: every one
@@ -27,8 +27,10 @@ jobs:
       # 5) are doing the right thing: a test job that ran no tests is not
       # a passing test job. The bootstrap PR therefore ships at least one
       # real test — see the bootstrap skill — rather than CI carrying a
-      # branch that reports SUCCESS having run nothing. A block scalar, so
-      # a multi-line fill (install, then a coverage-gated run) works.
+      # branch that reports SUCCESS having run nothing. Block scalar so a
+      # multi-line fill (install, then a coverage-gated run) works: every
+      # continuation line must start at column 10, like the line below, or
+      # the YAML fails to parse and takes all three jobs down with it.
       - name: Tests against the charter's floor
         run: |
           {{TEST_COMMAND_WITH_FLOOR}}

--- a/seed/workflows/ci.yml
+++ b/seed/workflows/ci.yml
@@ -23,18 +23,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # The bootstrap PR ships zero tests by design, and some runners exit
-      # non-zero when none are collected (Python >=3.12's unittest does).
-      # The guard is self-limiting: it stops applying the moment unit 1 lands
-      # its first test file, so nobody has to remember to remove it — and it
-      # can never mask a real suite, because a repo with tests takes the
-      # other branch. {{TEST_FILE_GLOBS}} is the charter's test layout, e.g.
-      # 'tests/test_*.py'.
+      # non-zero when none are collected (Python >=3.12's unittest exits 5).
+      # The probe is deliberately layout-independent and carries NO
+      # placeholder: it matches any tracked path containing "test" or
+      # "spec", so renaming the suffix, moving suites next to sources, or
+      # nesting a corpus can never route a repo that HAS tests into the
+      # skip branch — and an unfilled placeholder can never make this
+      # branch pass silently. It fails closed: the only way to skip is to
+      # have nothing test-shaped tracked at all, which is true exactly
+      # once, at bootstrap. Adapt the probe only if the stack genuinely
+      # names tests something else, and keep it broader than the charter's
+      # own layout.
       - name: Tests against the charter's floor, once any exist
         run: |
-          if [ -n "$(git ls-files {{TEST_FILE_GLOBS}})" ]; then
+          if [ -n "$(git ls-files '*test*' '*spec*')" ]; then
             {{TEST_COMMAND_WITH_FLOOR}}
           else
-            echo "No test files tracked yet — bootstrap state, nothing to run."
+            echo "Nothing test-shaped is tracked yet — bootstrap state."
           fi
 
   secrets:

--- a/seed/workflows/ci.yml
+++ b/seed/workflows/ci.yml
@@ -22,11 +22,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Tests with coverage floor
-        run: "{{TEST_COMMAND_WITH_COVERAGE_FLOOR}}"
+      # The bootstrap PR ships zero tests by design, and some runners exit
+      # non-zero when none are collected (Python >=3.12's unittest does).
+      # The guard is self-limiting: it stops applying the moment unit 1 lands
+      # its first test file, so nobody has to remember to remove it — and it
+      # can never mask a real suite, because a repo with tests takes the
+      # other branch. {{TEST_FILE_GLOBS}} is the charter's test layout, e.g.
+      # 'tests/test_*.py'.
+      - name: Tests against the charter's floor, once any exist
+        run: |
+          if [ -n "$(git ls-files {{TEST_FILE_GLOBS}})" ]; then
+            {{TEST_COMMAND_WITH_FLOOR}}
+          else
+            echo "No test files tracked yet — bootstrap state, nothing to run."
+          fi
 
   secrets:
     runs-on: ubuntu-latest
+    # gitleaks-action reads PR commits and posts leak comments through the
+    # workflow token. Under a repo whose default token is read-only it dies
+    # with "Resource not accessible by integration" before scanning anything,
+    # so the seed states the permissions it needs instead of inheriting a
+    # repo setting it never names.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/seed/workflows/ci.yml
+++ b/seed/workflows/ci.yml
@@ -22,25 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # The bootstrap PR ships zero tests by design, and some runners exit
-      # non-zero when none are collected (Python >=3.12's unittest exits 5).
-      # The probe is deliberately layout-independent and carries NO
-      # placeholder: it matches any tracked path containing "test" or
-      # "spec", so renaming the suffix, moving suites next to sources, or
-      # nesting a corpus can never route a repo that HAS tests into the
-      # skip branch — and an unfilled placeholder can never make this
-      # branch pass silently. It fails closed: the only way to skip is to
-      # have nothing test-shaped tracked at all, which is true exactly
-      # once, at bootstrap. Adapt the probe only if the stack genuinely
-      # names tests something else, and keep it broader than the charter's
-      # own layout.
-      - name: Tests against the charter's floor, once any exist
+      # No zero-test escape hatch, deliberately. Runners that exit
+      # non-zero when nothing is collected (Python >=3.12's unittest exits
+      # 5) are doing the right thing: a test job that ran no tests is not
+      # a passing test job. The bootstrap PR therefore ships at least one
+      # real test — see the bootstrap skill — rather than CI carrying a
+      # branch that reports SUCCESS having run nothing. A block scalar, so
+      # a multi-line fill (install, then a coverage-gated run) works.
+      - name: Tests against the charter's floor
         run: |
-          if [ -n "$(git ls-files '*test*' '*spec*')" ]; then
-            {{TEST_COMMAND_WITH_FLOOR}}
-          else
-            echo "Nothing test-shaped is tracked yet — bootstrap state."
-          fi
+          {{TEST_COMMAND_WITH_FLOOR}}
 
   secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why this change

The sofa-scratch round-two bootstrap (2026-08-20) hit six seed defects in one run, filed on Issue #13 as they surfaced. Every one makes a workload repo hand-patch the seed on its way in, differently each time — which turns the seed's "the copy is a divorce" promise into "copy, then improvise", and makes divergence invisible to any later session comparing against the template. One of the six caused real damage: auto-delete ate sofa-scratch's `staging` the first time Steve promoted to `main`.

## What changed

Six fixes for Issue #13, plus a seventh the adversarial lane found.

1. **Percentage-shaped test floor** (`seed/CLAUDE.md.template`, bootstrap step 1). `{{COVERAGE_FLOOR}}%` forced a fake number on any charter whose floor isn't a percentage. Now `{{TEST_FLOOR}}`, stated in whatever shape the subject has, required to be mechanically checkable by CI. sofa-scratch's charter had already gone off-template here ("The floor is corpus-shaped, not a percentage") — exactly the invisible divergence.
2. **CI assumed tests exist from the first commit** (`seed/workflows/ci.yml`). Python ≥3.12's unittest exits **5** on zero tests, so an honest bootstrap PR is red. Fixed by making the assumption true rather than guarding it: bootstrap step 3 now requires the bootstrap PR to ship at least one real test, and the `test` job has no zero-test escape hatch. Two attempts at a CI-side guard were removed as defects in their own right — see the review rounds below.
3. **`merge_dev.py` lint findings.** EXE001 (shebang, no exec bit — the blob was mode 100644, so there was nothing to preserve) fixed by committing it `100755`; ISC004 (implicit concatenation in the `--json` list) fixed by lifting the field list into a parenthesized `fields` local.
4. **`secrets` job had no `permissions:` block.** Under a read-only default workflow token, gitleaks-action dies with "Resource not accessible by integration" before scanning. Now declares `contents: read` / `pull-requests: write` at job level — the pattern `backlog-expiry.yml` in this same seed already used.
5. **No seeded `.gitignore`.** Added `seed/gitignore` → copied to `.gitignore`. Deliberately not `seed/.gitignore`, which would silently govern this repo's own `seed/` tree. The harm is specific: bytecode constant-folds split string literals, so a secret-shaped fixture never committed as source can land in history inside a `.pyc`.
6. **Auto-delete head branches deletes long-lived branches.** A promotion PR's head *is* the integration branch, so `staging → main` deleted `staging` (`dev` survived only by being default). See the fix round — the first version put this rule in the wrong file.
7. **(found by review) `{{HANDOFF_ISSUE}}`** is now a template slot. Steps 4 and 6 both required a handoff-issue line the template couldn't produce, so every bootstrap improvised it into the workload's governing rulebook; sofa-scratch's hand-written version is the evidence.

### What the adversarial lane changed

Six findings, four urgent-grade; all fixed in one round, all verified against `gh` first. Two are worth reading before merging, because they mean the first draft of this PR shipped new defects:

- **The zero-test guard was fail-open for the life of the repo.** Keying the skip on the charter's own globs means a repo that later renames `test_*.py` → `*_test.py` or moves suites under `src/` routes into the skip branch and reports SUCCESS with zero tests run — which `merge_dev.py` then accepts as a required check. That is the legacy failure mode (0005: hooks that never executed while everyone believed they ran) rebuilt inside the seed's own test gate. The replacement probe was *also* wrong (see the code-review lane), and the guard is now gone entirely.
- **The auto-delete rule was written on the wrong side of the divorce, and named two unreachable states.** It lived only in the bootstrap skill, which no workload repo receives, and required either an admin edit that 403s (Issue #14) or branch protection that private repos don't get (0005) — a bar every new repo starts out violating. The precondition now lives in `seed/CLAUDE.md.template`, checked at the moment it bites (before the first promotion PR), with the digest path as the reachable outcome.

Step 6 also now greps for **surviving seed placeholders** (`{{[A-Z_]\+}}`, not a bare `{{`, which would match the workflows' own `${{ secrets.GITHUB_TOKEN }}`) — the defect class this whole PR exists to close had no verification step until now.

### What the code-review lane changed

Five findings, all fixed in one round. Three were on code the *previous* fix round introduced, which is the useful signal: the second attempt at a zero-test guard matched test **tooling** rather than tests (`conftest.py`, `pytest.ini`, `vitest.config.ts` all match `*test*`), so a bootstrap PR wiring its stack would take the run branch with no tests and go red — defect 2 unfixed for the common Python and JS cases. Rather than patch the probe a third time, the guard was removed and its premise made true instead. The lane also caught that the new `{{` sweep would have failed on **every** bootstrap forever, since `${{ secrets.GITHUB_TOKEN }}` contains `{{`, and that `.env` did not cover the `.env.local` files `vercel env pull` writes on the stack this template targets.

## Verification

- **Defect 2 reproduced:** `python3 -m unittest discover` with zero tests exits **5** on Python 3.12.14 (measured).
- **Both rejected guards were measured, not argued:** the charter-glob version returns empty for a repo tracking `src/deep/widget_test.py` and `spec/thing_spec.js` (false green); the broad-probe version returns all five of `conftest.py`, `pytest.ini`, `requirements-test.txt`, `vitest.config.ts`, `spec/api-spec.yaml` in a repo with zero real tests (false red). Neither survives; there is no guard now.
- **Placeholder sweep checked against the real seed:** `{{[A-Z_]\+}}` matches all nine placeholders and zero Actions expressions.
- **`.env` fix checked against real filenames:** with `.env.*` + `!.env.example`, `git check-ignore` reports `.env.local` and `.env.production.local` ignored while `.env.example` stays tracked through `git add -A`.
- **Defect 3:** `ruff check --isolated --select E4,E7,E9,F,EXE,ISC,E501 seed/scripts/merge_dev.py` → "All checks passed!" (was 2 errors), and the file is back under its ≤78-column discipline. `evaluate()` unchanged: clean PR → no blockers, draft blocked, missing reviewer pass blocked.
- **Mode committed, not just local:** `git ls-files -s` shows `100755`.
- **Findings 3–5 confirmed live before acting:** `smansf/sofa-scratch` is `private`, `deleteBranchOnMerge: true`, `dev`/`staging`/`main` all `protected: false`; it runs `ruff check .` with no config file, so EXE001/ISC004 never fired there.
- **Not verified, and worth knowing:** the seed workflows aren't active in this repo (they live in `seed/`, not `.github/`), and no YAML parser is available here without installing one, so `ci.yml` was checked structurally rather than parsed. Its first real parse is wilson's bootstrap. Defects 4 and 6 are config-correct-by-construction — neither can be exercised until a repo is bootstrapped under them.
- CI: `why-this-change`, `secrets`, `tests`, `line-budget` all pass. `CLAUDE.md` untouched, so the line budget is unaffected.

Closes #13.

---

**Both lanes have run** (decisions/0003): adversarial — six findings, one round; code-review (`medium`, Steve's own session) — five findings, one round. Briefs, findings, and dispositions are all in the comments. No finding survives, CI is green, and the PR is out of draft. Merging is Steve's.
