### PR TITLE
Grant 4: App credentials and the least-privilege mint helper

### DIFF
--- a/governance/grants.md
+++ b/governance/grants.md
@@ -56,9 +56,17 @@ preconditions: this grant is **dormant until its rails exist as merged code**.
 
 ## Grant 4 — App credentials
 
-Supersedes the fine-grained PAT as the process's GitHub credential. Takes
-effect on merge; `~/.claude/CLAUDE.md`'s credential rule is then updated to
-match, and this file remains authoritative.
+**Dormant until its rails exist as merged code.** Supersedes the
+fine-grained PAT as the process's GitHub credential once active; until
+then the PAT rules stand and this grant is inert.
+
+- **Preconditions:** `seed/scripts/gh_token.py` is actually the credential
+  path — `merge_dev.py`, the seed workflows, and the `bootstrap` skill
+  obtain tokens through it and no ambient `GH_TOKEN` remains (sofa-claude
+  Issues #22, #23). Until those PRs merge, a declared credential no code
+  calls is prose, not a rail (decisions/0003), and merging this grant
+  alone would raise the App's ceiling before the control that answers it
+  is load-bearing.
 
 - The GitHub surface is a GitHub App (`sofa-claude-ops`), not a personal
   access token. Its private key lives outside any repository, mode 600,
@@ -66,38 +74,76 @@ match, and this file remains authoritative.
   only. Registering the App, generating its key, and installing it on an
   account remain Steve's ceremonies, forbidden to Claude like every other
   credential-granting flow.
-- **Least privilege is the only mint path.** Every token names the
+
+- **Least privilege is the sanctioned mint path.** Every token names the
   repositories it touches and the permissions it needs, and carries
-  nothing else. `seed/scripts/gh_token.py` is the single sanctioned way to
-  obtain one; it refuses to mint without both. There is no unscoped path,
-  by construction rather than by convention.
-- **Elevation is deliberate, bounded, and announced.** `administration`
-  and `organization_administration` are requested only by bootstrap's two
-  call sites — repo creation, and setting a default branch or applying a
-  ruleset — never by ongoing work. Requesting either requires a stated
-  reason, echoed to stderr so a transcript shows every elevation.
+  nothing else. `seed/scripts/gh_token.py` refuses to mint without both.
+  This is a paved path, not a wall: the capability is the private key, and
+  anything holding the key can sign a JWT and request everything the
+  installation allows. The helper constrains the process's own conduct —
+  it is not a boundary an actor outside the process is held by, and this
+  grant does not pretend otherwise (decisions/0001).
+
+- **What scoping does and does not bound.** A token's `repositories` list
+  bounds **repository-level** permissions only. **Organization-level**
+  permissions — `organization_administration`, `members`,
+  `organization_secrets` — are installation-wide and ignore that list
+  entirely, as verified against the API on 2026-08-20: a token scoped to
+  one throwaway repo performed an org-level repository creation. Any mint
+  including an org-level permission is org-wide for its lifetime. No
+  scoping arrangement changes this.
+
+- **Elevation is confined by interface, not by scope.** Because org-level
+  permission cannot be bounded, it is not offered as a permission a caller
+  may request. `gh_token.py` exposes exactly one operation that uses it —
+  repository creation — which mints, acts, and discards internally; the
+  command line refuses org-level permissions outright. There is no way,
+  within the process, to obtain a reusable org-admin token. This is
+  containment of the interface, not of the credential.
+
+- **Every elevation is recorded durably.** Requesting an elevated
+  permission requires a stated reason and appends an audit record —
+  timestamp, account, repositories, permissions, reason, never the token —
+  to the elevation log. A stderr line is not a record: under Grant 1 no
+  one is watching the terminal, and an announcement no one can read later
+  is not a control.
+
 - **No standing token.** Tokens are minted per operation, expire within
   the hour, and are passed to a single child process. None is written to
   disk, exported into a shell, or left in `GH_TOKEN` between commands.
-- **Deletion has no call site.** GitHub bundles repository deletion into
-  `administration` and does not let us split it off, so an admin-bearing
-  token can delete the repositories in its scope. That reach is bounded by
-  scoping: wiring tokens name the single repo being wired, and creation
-  tokens — which cannot be scoped to nothing, as an empty list silently
-  means all — name the throwaway scratch repo. A real workload repo is
-  never inside an admin-bearing token's scope once its bootstrap ends.
+  The helper offers no way to print a token to stdout, because in this
+  environment stdout is captured into a session transcript on disk and
+  into model context, where it outlives the command that needed it.
+
+- **The elevated permission carries more than deletion.** Repository
+  `administration` is what applies a ruleset — and therefore what can
+  remove one. The human-only merge gate on `staging` and `main` is
+  platform config sitting inside the same permission bootstrap needs to
+  create it, so a wiring token can strip the gate, after which an ordinary
+  `contents` token merges to `main` without breaching any rule stated
+  here. Bootstrap therefore verifies protection by behaviour — attempting
+  a write and requiring the refusal — never by trusting a success code
+  (Issue #23). GitHub bundles repository deletion into the same
+  permission and does not let us split it off.
+
 - **The widening is recorded, not glossed.** Steve granted the App
   organization-level Administration on `warblersafety` (2026-08-20),
   moving its ceiling from per-repo to org-wide: within that org the App
-  can in principle delete repositories and change membership. Nothing in
-  the process invokes either, and scoped minting is the compensating
-  control that keeps the working credential far below that ceiling. The
-  ceiling is real and this grant names it rather than relying on it going
-  unnoticed.
+  can in principle delete repositories, change settings, and change
+  membership. Repository deletion was already reachable before that grant,
+  since rulesets require repository `administration`; what the org-level
+  grant adds is repository creation, org settings, and membership. Steve
+  accepted this knowingly on 2026-08-20 after the scoping claim above was
+  corrected. The controls are confinement to one interface, a durable
+  audit record, and behavioural verification of protection — discipline
+  and detection, not containment. Naming that plainly is the point of
+  this bullet.
+
 - Grant 1 is unchanged and still dormant: nothing here creates a daemon,
   timer, or self-refreshing process. Token minting happens on demand
   inside active work. Tokens minted inside GitHub Actions come from
   `actions/create-github-app-token` and repo secrets, authorized by
   Steve's merge of the workflow file, per Grant 1.
-- Revoking works in reverse: Steve uninstalls the App or reverts this
-  grant on `main`.
+
+- Revoking works in reverse: Steve uninstalls the App, removes a
+  permission from it, or reverts this grant on `main`.

--- a/governance/grants.md
+++ b/governance/grants.md
@@ -53,3 +53,51 @@ preconditions: this grant is **dormant until its rails exist as merged code**.
 - The Claude Code auto-updater is enabled on this account.
 - The "stop and hand back to Steve" rule applies to installing *new* tools
   only, not to updating tools already granted user-locally.
+
+## Grant 4 — App credentials
+
+Supersedes the fine-grained PAT as the process's GitHub credential. Takes
+effect on merge; `~/.claude/CLAUDE.md`'s credential rule is then updated to
+match, and this file remains authoritative.
+
+- The GitHub surface is a GitHub App (`sofa-claude-ops`), not a personal
+  access token. Its private key lives outside any repository, mode 600,
+  and is never read, printed, copied, or transmitted — presence checks
+  only. Registering the App, generating its key, and installing it on an
+  account remain Steve's ceremonies, forbidden to Claude like every other
+  credential-granting flow.
+- **Least privilege is the only mint path.** Every token names the
+  repositories it touches and the permissions it needs, and carries
+  nothing else. `seed/scripts/gh_token.py` is the single sanctioned way to
+  obtain one; it refuses to mint without both. There is no unscoped path,
+  by construction rather than by convention.
+- **Elevation is deliberate, bounded, and announced.** `administration`
+  and `organization_administration` are requested only by bootstrap's two
+  call sites — repo creation, and setting a default branch or applying a
+  ruleset — never by ongoing work. Requesting either requires a stated
+  reason, echoed to stderr so a transcript shows every elevation.
+- **No standing token.** Tokens are minted per operation, expire within
+  the hour, and are passed to a single child process. None is written to
+  disk, exported into a shell, or left in `GH_TOKEN` between commands.
+- **Deletion has no call site.** GitHub bundles repository deletion into
+  `administration` and does not let us split it off, so an admin-bearing
+  token can delete the repositories in its scope. That reach is bounded by
+  scoping: wiring tokens name the single repo being wired, and creation
+  tokens — which cannot be scoped to nothing, as an empty list silently
+  means all — name the throwaway scratch repo. A real workload repo is
+  never inside an admin-bearing token's scope once its bootstrap ends.
+- **The widening is recorded, not glossed.** Steve granted the App
+  organization-level Administration on `warblersafety` (2026-08-20),
+  moving its ceiling from per-repo to org-wide: within that org the App
+  can in principle delete repositories and change membership. Nothing in
+  the process invokes either, and scoped minting is the compensating
+  control that keeps the working credential far below that ceiling. The
+  ceiling is real and this grant names it rather than relying on it going
+  unnoticed.
+- Grant 1 is unchanged and still dormant: nothing here creates a daemon,
+  timer, or self-refreshing process. Token minting happens on demand
+  inside active work. Tokens minted inside GitHub Actions come from
+  `actions/create-github-app-token` and repo secrets, authorized by
+  Steve's merge of the workflow file, per Grant 1.
+- Revoking works in reverse: Steve uninstalls the App or reverts this
+  grant on `main`.

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -121,21 +121,41 @@ def api(path, bearer, method="GET", payload=None):
 
 
 def installation_id(account, jwt):
-    """The App's installation on `account` (an org or user login)."""
-    for inst in api("/app/installations", jwt):
-        if ((inst.get("account") or {}).get("login") or "").lower() == account.lower():
-            return inst["id"]
+    """The App's installation on `account` (an org or user login).
+
+    Paginated: the default page size is 30, and reporting "no installation"
+    for an account on page two would send the operator off to redo a
+    ceremony that is already done.
+    """
+    page, per_page = 1, 100
+    while True:
+        batch = api(f"/app/installations?per_page={per_page}&page={page}", jwt)
+        for inst in batch:
+            if ((inst.get("account") or {}).get("login") or "").lower() == account.lower():
+                return inst["id"]
+        if len(batch) < per_page:
+            break
+        page += 1
     raise TokenError(
         f"The App has no installation on {account!r}. Install it there first "
         f"-- installing an App is Steve's step, not Claude's.")
 
 
-def record_elevation(account, repositories, permissions, reason, audit_path=None):
-    """Append a durable audit record. Fails closed: no record, no token."""
+def record_elevation(account, repositories, permissions, reason,
+                     audit_path=None, event="requested"):
+    """Append a durable audit record. Fails closed: no record, no token.
+
+    Written twice per elevation: `requested` before minting, so a failure
+    to record blocks the mint, and `granted` once a token actually exists.
+    A lone `requested` therefore means the elevation was authorised but
+    never happened -- a missing key, a rejected call -- which keeps the log
+    from implying access that was never obtained.
+    """
     path = pathlib.Path(os.path.expanduser(
         audit_path or os.environ.get("SOFA_AUDIT_LOG") or DEFAULT_AUDIT))
     entry = {
         "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "event": event,
         "account": account,
         "repositories": sorted(repositories),
         "permissions": dict(sorted(permissions.items())),
@@ -198,20 +218,43 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
     result = api(f"/app/installations/{installation_id(account, jwt)}/access_tokens",
                  jwt, "POST",
                  {"repositories": list(repositories), "permissions": dict(permissions)})
+    if elevated:
+        record_elevation(account, repositories, permissions, reason,
+                         event="granted")
     return result["token"], result.get("expires_at")
 
 
-def create_repo(org, name, reason, private=True, app_id=None, key_path=None):
+def create_repo(org, name, reason, scope_repo, private=True,
+                app_id=None, key_path=None):
     """Create `org/name`. The only operation permitted org-level access.
 
-    The org-admin token is minted, used once, and dropped -- it is never
-    returned, so no caller can reuse it for anything else. GitHub requires
-    BOTH organization-level and repository-level administration here
-    (verified 2026-08-20); the repository list cannot bound the former.
+    The org-admin token is minted, used once, and dropped -- never
+    returned, so no caller can reuse it. GitHub requires BOTH
+    organization-level and repository-level administration here (verified
+    2026-08-20).
+
+    `scope_repo` must name an **existing** repository. The token cannot be
+    scoped to the repo being created -- it does not exist yet, and GitHub
+    rejects a repository list naming anything absent -- and it cannot be
+    scoped to nothing, since an empty list silently means all. So the
+    repository-level half of this token lands on whichever existing repo
+    is named: pass the throwaway scratch repo, whose admin exposure costs
+    nothing. The org-level half is installation-wide regardless; no
+    scoping arrangement changes that (Grant 4).
+
+    Consequence worth knowing at bootstrap time: an org with no
+    repositories at all has nothing to scope to, so its first repository
+    is Steve's to create by hand.
     """
     if not (reason or "").strip():
         raise TokenError("create_repo requires a stated reason.")
-    token, _ = mint(org, [name],
+    if not scope_repo or scope_repo == name:
+        raise TokenError(
+            f"create_repo needs scope_repo to name an EXISTING repository, "
+            f"not {name!r}, which does not exist yet. GitHub rejects a "
+            f"repository list containing anything absent, and an empty list "
+            f"silently means all -- pass the throwaway scratch repo.")
+    token, _ = mint(org, [scope_repo],
                     {"organization_administration": "write",
                      "administration": "write"},
                     reason=reason, app_id=app_id, key_path=key_path,
@@ -242,7 +285,9 @@ def main(argv=None):
                         help="-- CMD ARGS: run CMD with GH_TOKEN set")
     args = parser.parse_args(argv)
 
-    command = [a for a in args.command if a != "--"]
+    # argparse.REMAINDER keeps the separator; drop only that leading one,
+    # never a `--` the child command means for itself (e.g. `git diff -- path`).
+    command = args.command[1:] if args.command[:1] == ["--"] else list(args.command)
     if not command:
         parser.error("give a command after -- ; this tool runs a command "
                      "under a token, it does not hand the token out")

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Mint a short-lived, least-privilege GitHub App installation token.
+
+Every GitHub credential this process uses comes from here. There is no
+unscoped path: callers name the repositories and the permissions, and get
+a token that carries those and nothing else. The App's ceiling stays high;
+the working credential sits far below it (governance/grants.md, Grant 4).
+
+Elevated permissions -- `administration` (which GitHub bundles repository
+deletion into) and `organization_administration` -- additionally require a
+stated reason, which is echoed to stderr. Elevation is meant to be rare,
+deliberate, and visible in a transcript, not ambient.
+
+Prefer `--exec`, which sets GH_TOKEN for one child process only, so the
+token never reaches stdout, a log, or a shell variable that outlives the
+command. `--print` exists for callers that genuinely cannot use `--exec`.
+
+Configuration (no value is ever hardcoded):
+    SOFA_APP_ID    the App's numeric ID
+    SOFA_APP_KEY   path to its PEM private key (default ~/.config/sofa-claude/app.pem)
+
+Usage:
+    gh_token.py --account ORG --repos a,b --perm contents=write -- gh pr list
+    gh_token.py --account ORG --repos a --perm administration=write \
+                --reason "bootstrap: apply protect-main ruleset" -- ...
+"""
+
+import argparse
+import base64
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+DEFAULT_KEY = "~/.config/sofa-claude/app.pem"
+# GitHub bundles repository deletion into `administration`; it cannot be
+# split off. Requesting either of these must therefore be deliberate.
+ELEVATED = ("administration", "organization_administration")
+
+
+class TokenError(RuntimeError):
+    """Raised with an actionable message; never carries a credential."""
+
+
+def _b64(raw):
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def app_jwt(app_id, key_path, now=None):
+    """Sign a ~9-minute JWT with the App's private key, via openssl."""
+    path = pathlib.Path(os.path.expanduser(key_path))
+    if not path.exists():
+        raise TokenError(
+            f"App private key not found at {path}. Set SOFA_APP_KEY, or place "
+            f"the key there with mode 600. Generating or moving keys is "
+            f"Steve's ceremony -- do not create one to get past this.")
+    if not os.access(path, os.R_OK):
+        raise TokenError(f"App private key at {path} exists but is unreadable.")
+    now = int(time.time() if now is None else now)
+    header = _b64(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _b64(json.dumps(
+        {"iat": now - 60, "exp": now + 540, "iss": str(app_id)}).encode())
+    signing_input = header + b"." + payload
+    try:
+        proc = subprocess.run(["openssl", "dgst", "-sha256", "-sign", str(path)],
+                              input=signing_input, capture_output=True)
+    except FileNotFoundError:
+        raise TokenError("openssl not found on PATH; cannot sign the App JWT.")
+    if proc.returncode != 0:
+        raise TokenError(
+            f"Signing the App JWT with {path} failed -- is it a valid RSA "
+            f"private key? openssl: {proc.stderr.decode().strip()[:200]}")
+    return (signing_input + b"." + _b64(proc.stdout)).decode()
+
+
+def api(path, bearer, method="GET", payload=None):
+    request = urllib.request.Request(
+        API + path, method=method,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        headers={"Authorization": "Bearer " + bearer,
+                 "Accept": "application/vnd.github+json",
+                 "X-GitHub-Api-Version": "2022-11-28",
+                 "User-Agent": "sofa-claude"})
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as err:
+        detail = ""
+        try:
+            detail = json.loads(err.read()).get("message", "")
+        except Exception:
+            pass
+        raise TokenError(f"GitHub {err.code} on {method} {path}: {detail}")
+
+
+def installation_id(account, jwt):
+    """The App's installation on `account` (an org or user login)."""
+    for inst in api("/app/installations", jwt):
+        if ((inst.get("account") or {}).get("login") or "").lower() == account.lower():
+            return inst["id"]
+    raise TokenError(
+        f"The App has no installation on {account!r}. Install it there first "
+        f"-- installing an App is Steve's step, not Claude's.")
+
+
+def mint(account, repositories, permissions, reason=None,
+         app_id=None, key_path=None):
+    """Return a short-lived token carrying exactly `permissions` on `repositories`.
+
+    `repositories` and `permissions` are required and must be non-empty:
+    there is deliberately no way to ask this function for everything the
+    installation can do.
+    """
+    if not repositories:
+        raise TokenError(
+            "Refusing to mint: no repositories named. Least privilege is the "
+            "only path -- name the repositories this task actually touches.")
+    if not permissions:
+        raise TokenError(
+            "Refusing to mint: no permissions named. Least privilege is the "
+            "only path -- name the permissions this task actually needs.")
+    elevated = sorted(p for p in permissions if p in ELEVATED)
+    if elevated and not (reason or "").strip():
+        raise TokenError(
+            f"Refusing to mint {', '.join(elevated)} without a stated reason. "
+            f"These carry repository deletion, which GitHub does not let us "
+            f"split off. Pass --reason naming the single call this is for.")
+    app_id = app_id or os.environ.get("SOFA_APP_ID")
+    if not app_id:
+        raise TokenError("SOFA_APP_ID is not set; it is the App's numeric ID.")
+    key_path = key_path or os.environ.get("SOFA_APP_KEY") or DEFAULT_KEY
+    if elevated:
+        print(f"[gh_token] elevated ({', '.join(elevated)}) on "
+              f"{account}/{{{','.join(repositories)}}}: {reason.strip()}",
+              file=sys.stderr)
+    jwt = app_jwt(app_id, key_path)
+    result = api(f"/app/installations/{installation_id(account, jwt)}/access_tokens",
+                 jwt, "POST",
+                 {"repositories": list(repositories), "permissions": dict(permissions)})
+    return result["token"], result.get("expires_at")
+
+
+def _permission(arg):
+    if "=" not in arg:
+        raise argparse.ArgumentTypeError(
+            f"--perm expects name=level, e.g. contents=write (got {arg!r})")
+    name, _, level = arg.partition("=")
+    return name.strip(), level.strip()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Mint a scoped, short-lived GitHub App token.")
+    parser.add_argument("--account", required=True,
+                        help="org or user login the App is installed on")
+    parser.add_argument("--repos", required=True,
+                        help="comma-separated repository names (not full names)")
+    parser.add_argument("--perm", required=True, action="append", type=_permission,
+                        metavar="NAME=LEVEL", help="repeatable; e.g. contents=write")
+    parser.add_argument("--reason", help="required for elevated permissions")
+    parser.add_argument("--print", dest="print_token", action="store_true",
+                        help="print the token to stdout (prefer -- CMD instead)")
+    parser.add_argument("command", nargs=argparse.REMAINDER,
+                        help="-- CMD ARGS: run CMD with GH_TOKEN set, token never printed")
+    args = parser.parse_args(argv)
+
+    command = [a for a in args.command if a != "--"]
+    if not command and not args.print_token:
+        parser.error("give a command after -- , or pass --print if you truly "
+                     "need the token itself")
+    try:
+        token, expires = mint(args.account,
+                              [r.strip() for r in args.repos.split(",") if r.strip()],
+                              dict(args.perm), args.reason)
+    except TokenError as err:
+        print(f"CREDENTIAL FAILURE -- nothing was minted.\n{err}", file=sys.stderr)
+        return 2
+    if command:
+        env = dict(os.environ, GH_TOKEN=token, GITHUB_TOKEN=token)
+        return subprocess.run(command, env=env).returncode
+    print(f"[gh_token] expires {expires}", file=sys.stderr)
+    print(token)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -1,32 +1,47 @@
 #!/usr/bin/env python3
 """Mint a short-lived, least-privilege GitHub App installation token.
 
-Every GitHub credential this process uses comes from here. There is no
-unscoped path: callers name the repositories and the permissions, and get
-a token that carries those and nothing else. The App's ceiling stays high;
-the working credential sits far below it (governance/grants.md, Grant 4).
+Every GitHub credential this process uses comes from here. Callers name
+the repositories and the permissions, and get a token carrying those and
+nothing else. This is a paved path, not a wall -- the capability is the
+private key, and anything holding it can request whatever the installation
+allows. What this module constrains is the process's own conduct
+(governance/grants.md, Grant 4).
 
-Elevated permissions -- `administration` (which GitHub bundles repository
-deletion into) and `organization_administration` -- additionally require a
-stated reason, which is echoed to stderr. Elevation is meant to be rare,
-deliberate, and visible in a transcript, not ambient.
+Two limits are worth stating because they are counter-intuitive:
 
-Prefer `--exec`, which sets GH_TOKEN for one child process only, so the
-token never reaches stdout, a log, or a shell variable that outlives the
-command. `--print` exists for callers that genuinely cannot use `--exec`.
+* A token's repository list bounds REPOSITORY-level permissions only.
+  ORG-level permissions are installation-wide and ignore it entirely --
+  verified against the API, not inferred. So org-level permission is not
+  offered as something a caller may request: `create_repo()` is the one
+  operation that uses it, minting and discarding internally, and the
+  command line refuses org-level permissions outright.
+
+* `administration` is what applies a ruleset, and therefore what can
+  remove one -- the human-only merge gate lives inside the same permission
+  bootstrap needs to create it. GitHub bundles repository deletion in
+  there too and will not let us split it off.
+
+Elevated permissions require a stated reason and append an audit record.
+If the record cannot be written, nothing is minted: no record, no
+elevation. There is deliberately no way to print a token to stdout --
+in this environment stdout lands in a transcript on disk and in model
+context, where it would outlive the command that needed it.
 
 Configuration (no value is ever hardcoded):
-    SOFA_APP_ID    the App's numeric ID
-    SOFA_APP_KEY   path to its PEM private key (default ~/.config/sofa-claude/app.pem)
+    SOFA_APP_ID     the App's numeric ID
+    SOFA_APP_KEY    path to its PEM private key (default ~/.config/sofa-claude/app.pem)
+    SOFA_AUDIT_LOG  elevation record (default ~/.config/sofa-claude/elevations.log)
 
 Usage:
     gh_token.py --account ORG --repos a,b --perm contents=write -- gh pr list
     gh_token.py --account ORG --repos a --perm administration=write \
-                --reason "bootstrap: apply protect-main ruleset" -- ...
+                --reason "bootstrap: apply protect-main ruleset" -- gh api ...
 """
 
 import argparse
 import base64
+import datetime
 import json
 import os
 import pathlib
@@ -38,9 +53,16 @@ import urllib.request
 
 API = "https://api.github.com"
 DEFAULT_KEY = "~/.config/sofa-claude/app.pem"
-# GitHub bundles repository deletion into `administration`; it cannot be
-# split off. Requesting either of these must therefore be deliberate.
-ELEVATED = ("administration", "organization_administration")
+DEFAULT_AUDIT = "~/.config/sofa-claude/elevations.log"
+
+# Installation-wide: a token's repository list does NOT bound these.
+ORG_LEVEL = ("organization_administration", "members", "organization_secrets",
+             "organization_projects", "organization_hooks",
+             "organization_self_hosted_runners", "organization_user_blocking")
+# Requesting any of these requires a reason and leaves an audit record.
+# `administration` carries deletion AND ruleset removal; `secrets`,
+# `actions` and `workflows` can install or feed code that runs with them.
+ELEVATED = ORG_LEVEL + ("administration", "secrets", "actions", "workflows")
 
 
 class TokenError(RuntimeError):
@@ -108,13 +130,38 @@ def installation_id(account, jwt):
         f"-- installing an App is Steve's step, not Claude's.")
 
 
-def mint(account, repositories, permissions, reason=None,
-         app_id=None, key_path=None):
-    """Return a short-lived token carrying exactly `permissions` on `repositories`.
+def record_elevation(account, repositories, permissions, reason, audit_path=None):
+    """Append a durable audit record. Fails closed: no record, no token."""
+    path = pathlib.Path(os.path.expanduser(
+        audit_path or os.environ.get("SOFA_AUDIT_LOG") or DEFAULT_AUDIT))
+    entry = {
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "account": account,
+        "repositories": sorted(repositories),
+        "permissions": dict(sorted(permissions.items())),
+        "reason": reason.strip(),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
+    except OSError as err:
+        raise TokenError(
+            f"Refusing to mint: the elevation could not be recorded at {path} "
+            f"({err}). An elevation no one can audit later is not a control "
+            f"(Grant 4) -- fix the path or the permissions, do not proceed.")
+    return entry
 
-    `repositories` and `permissions` are required and must be non-empty:
-    there is deliberately no way to ask this function for everything the
-    installation can do.
+
+def mint(account, repositories, permissions, reason=None, app_id=None,
+         key_path=None, _allow_org_level=False):
+    """Return (token, expires_at) carrying exactly `permissions` on `repositories`.
+
+    Both scoping arguments are required and must be non-empty: there is
+    deliberately no way to ask for everything the installation can do.
+    Org-level permissions are rejected here -- they cannot be bounded by
+    the repository list, so they are reachable only through the single
+    operation that needs them (`create_repo`).
     """
     if not repositories:
         raise TokenError(
@@ -124,25 +171,53 @@ def mint(account, repositories, permissions, reason=None,
         raise TokenError(
             "Refusing to mint: no permissions named. Least privilege is the "
             "only path -- name the permissions this task actually needs.")
+    org_level = sorted(p for p in permissions if p in ORG_LEVEL)
+    if org_level and not _allow_org_level:
+        raise TokenError(
+            f"Refusing to mint {', '.join(org_level)}: organization-level "
+            f"permissions are installation-wide and are NOT bounded by the "
+            f"repository list, so there is no such thing as a scoped one. "
+            f"They are reachable only through create_repo(), which mints and "
+            f"discards internally (Grant 4).")
     elevated = sorted(p for p in permissions if p in ELEVATED)
     if elevated and not (reason or "").strip():
         raise TokenError(
             f"Refusing to mint {', '.join(elevated)} without a stated reason. "
-            f"These carry repository deletion, which GitHub does not let us "
-            f"split off. Pass --reason naming the single call this is for.")
+            f"`administration` carries repository deletion and ruleset "
+            f"removal, which GitHub does not let us split off. Pass --reason "
+            f"naming the single call this is for.")
     app_id = app_id or os.environ.get("SOFA_APP_ID")
     if not app_id:
         raise TokenError("SOFA_APP_ID is not set; it is the App's numeric ID.")
     key_path = key_path or os.environ.get("SOFA_APP_KEY") or DEFAULT_KEY
     if elevated:
-        print(f"[gh_token] elevated ({', '.join(elevated)}) on "
-              f"{account}/{{{','.join(repositories)}}}: {reason.strip()}",
-              file=sys.stderr)
+        entry = record_elevation(account, repositories, permissions, reason)
+        print(f"[gh_token] elevated ({', '.join(elevated)}) recorded: "
+              f"{entry['reason']}", file=sys.stderr)
     jwt = app_jwt(app_id, key_path)
     result = api(f"/app/installations/{installation_id(account, jwt)}/access_tokens",
                  jwt, "POST",
                  {"repositories": list(repositories), "permissions": dict(permissions)})
     return result["token"], result.get("expires_at")
+
+
+def create_repo(org, name, reason, private=True, app_id=None, key_path=None):
+    """Create `org/name`. The only operation permitted org-level access.
+
+    The org-admin token is minted, used once, and dropped -- it is never
+    returned, so no caller can reuse it for anything else. GitHub requires
+    BOTH organization-level and repository-level administration here
+    (verified 2026-08-20); the repository list cannot bound the former.
+    """
+    if not (reason or "").strip():
+        raise TokenError("create_repo requires a stated reason.")
+    token, _ = mint(org, [name],
+                    {"organization_administration": "write",
+                     "administration": "write"},
+                    reason=reason, app_id=app_id, key_path=key_path,
+                    _allow_org_level=True)
+    return api(f"/orgs/{org}/repos", token, "POST",
+               {"name": name, "private": bool(private), "auto_init": True})
 
 
 def _permission(arg):
@@ -155,7 +230,7 @@ def _permission(arg):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
-        description="Mint a scoped, short-lived GitHub App token.")
+        description="Run a command under a scoped, short-lived GitHub App token.")
     parser.add_argument("--account", required=True,
                         help="org or user login the App is installed on")
     parser.add_argument("--repos", required=True,
@@ -163,29 +238,23 @@ def main(argv=None):
     parser.add_argument("--perm", required=True, action="append", type=_permission,
                         metavar="NAME=LEVEL", help="repeatable; e.g. contents=write")
     parser.add_argument("--reason", help="required for elevated permissions")
-    parser.add_argument("--print", dest="print_token", action="store_true",
-                        help="print the token to stdout (prefer -- CMD instead)")
     parser.add_argument("command", nargs=argparse.REMAINDER,
-                        help="-- CMD ARGS: run CMD with GH_TOKEN set, token never printed")
+                        help="-- CMD ARGS: run CMD with GH_TOKEN set")
     args = parser.parse_args(argv)
 
     command = [a for a in args.command if a != "--"]
-    if not command and not args.print_token:
-        parser.error("give a command after -- , or pass --print if you truly "
-                     "need the token itself")
+    if not command:
+        parser.error("give a command after -- ; this tool runs a command "
+                     "under a token, it does not hand the token out")
     try:
-        token, expires = mint(args.account,
-                              [r.strip() for r in args.repos.split(",") if r.strip()],
-                              dict(args.perm), args.reason)
+        token, _ = mint(args.account,
+                        [r.strip() for r in args.repos.split(",") if r.strip()],
+                        dict(args.perm), args.reason)
     except TokenError as err:
         print(f"CREDENTIAL FAILURE -- nothing was minted.\n{err}", file=sys.stderr)
         return 2
-    if command:
-        env = dict(os.environ, GH_TOKEN=token, GITHUB_TOKEN=token)
-        return subprocess.run(command, env=env).returncode
-    print(f"[gh_token] expires {expires}", file=sys.stderr)
-    print(token)
-    return 0
+    env = dict(os.environ, GH_TOKEN=token, GITHUB_TOKEN=token)
+    return subprocess.run(command, env=env).returncode
 
 
 if __name__ == "__main__":

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -27,7 +27,7 @@ def _mint(*args, **kwargs):
     captured = {}
 
     def fake_api(path, bearer, method="GET", payload=None):
-        if path == "/app/installations":
+        if path.startswith("/app/installations?"):
             return [{"id": 42, "account": {"login": "warblersafety"}}]
         captured["path"] = path
         captured["payload"] = payload
@@ -148,17 +148,30 @@ class OrgLevelTests(unittest.TestCase):
                                   "--reason", "trying it on", "--", "true"])
         self.assertEqual(code, 2)
 
-    def test_create_repo_does_not_return_the_token(self):
+    def _create(self, **over):
         seen = {}
 
-        def fake_mint(*args, **kwargs):
-            seen["permissions"] = args[2]
+        def fake_mint(account, repositories, permissions, **kwargs):
+            seen["repositories"] = repositories
+            seen["permissions"] = permissions
             seen["allow"] = kwargs.get("_allow_org_level")
             return "ghs_secret", "2026-08-21T00:00:00Z"
 
+        kwargs = dict(reason="bootstrap", scope_repo="scratch")
+        kwargs.update(over)
         with mock.patch.object(gh_token, "mint", fake_mint), \
              mock.patch.object(gh_token, "api", lambda *a, **k: {"full_name": "o/r"}):
-            result = gh_token.create_repo("warblersafety", "r", reason="bootstrap")
+            result = gh_token.create_repo("warblersafety", "wilson", **kwargs)
+        return result, seen
+
+    def test_create_repo_scopes_to_an_existing_repo_not_the_new_one(self):
+        """The repo being created does not exist yet; GitHub 422s on it."""
+        _, seen = self._create()
+        self.assertEqual(seen["repositories"], ["scratch"])
+        self.assertNotIn("wilson", seen["repositories"])
+
+    def test_create_repo_does_not_return_the_token(self):
+        result, seen = self._create()
         self.assertEqual(result, {"full_name": "o/r"})
         self.assertNotIn("ghs_secret", json.dumps(result))
         self.assertTrue(seen["allow"])
@@ -167,7 +180,16 @@ class OrgLevelTests(unittest.TestCase):
 
     def test_create_repo_requires_a_reason(self):
         with self.assertRaises(gh_token.TokenError):
-            gh_token.create_repo("warblersafety", "r", reason="")
+            self._create(reason="")
+
+    def test_create_repo_refuses_to_scope_to_the_repo_being_created(self):
+        with self.assertRaises(gh_token.TokenError) as caught:
+            self._create(scope_repo="wilson")
+        self.assertIn("does not exist yet", str(caught.exception))
+
+    def test_create_repo_refuses_an_empty_scope(self):
+        with self.assertRaises(gh_token.TokenError):
+            self._create(scope_repo="")
 
 
 class AuditTests(unittest.TestCase):
@@ -181,6 +203,7 @@ class AuditTests(unittest.TestCase):
             entry = json.loads(log.read_text().strip())
         self.assertEqual(entry["repositories"], ["scratch"])
         self.assertEqual(entry["reason"], "bootstrap: apply protect-main")
+        self.assertEqual(entry["event"], "requested")
         self.assertIn("at", entry)
 
     def test_record_never_contains_a_token(self):
@@ -230,13 +253,64 @@ class NoCredentialLeakTests(unittest.TestCase):
         self.assertNotIn("ghs_secret", " ".join(captured["command"]))
 
 
+class ArgumentTests(unittest.TestCase):
+    def test_only_the_leading_separator_is_stripped(self):
+        """`--` inside the child command is the child's, not argparse's."""
+        captured = {}
+
+        def fake_run(command, env=None):
+            captured["command"] = command
+            return subprocess.CompletedProcess(command, 0)
+
+        with mock.patch.object(gh_token, "mint",
+                               lambda *a, **k: ("ghs_secret", "later")), \
+             mock.patch.object(gh_token.subprocess, "run", fake_run):
+            gh_token.main(["--account", "o", "--repos", "r", "--perm",
+                           "contents=write", "--",
+                           "git", "diff", "main", "--", "seed/"])
+        self.assertEqual(captured["command"],
+                         ["git", "diff", "main", "--", "seed/"])
+
+
+class ElevationRecordPairingTests(unittest.TestCase):
+    def test_a_failed_mint_leaves_only_a_request(self):
+        """A `requested` with no `granted` means access was never obtained."""
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "elevations.log"
+            with mock.patch.dict(os.environ, {"SOFA_AUDIT_LOG": str(log),
+                                              "SOFA_APP_ID": "1"}), \
+                 mock.patch.object(sys, "stderr", io.StringIO()), \
+                 mock.patch.object(gh_token, "app_jwt",
+                                   mock.Mock(side_effect=gh_token.TokenError("no key"))):
+                with self.assertRaises(gh_token.TokenError):
+                    gh_token.mint("o", ["r"], {"administration": "write"},
+                                  reason="wiring")
+            events = [json.loads(line)["event"]
+                      for line in log.read_text().splitlines()]
+        self.assertEqual(events, ["requested"])
+
+
 class NoStandingExecutionTests(unittest.TestCase):
-    def test_helper_starts_no_daemon_or_timer(self):
-        """Grant 1 is dormant: nothing here may begin work on its own."""
-        source = _path.read_text()
-        for forbidden in ("threading", "sched", "daemon", "launchd",
-                          "crontab", "LaunchAgent", "while True"):
-            self.assertNotIn(forbidden, source)
+    def test_helper_imports_nothing_that_can_schedule_work(self):
+        """Grant 1 is dormant: nothing here may begin work on its own.
+
+        Tests the module's imports rather than its source text -- a loop
+        that pages an API is not a timer, and a spelling check cannot tell
+        the difference.
+        """
+        imported = {name.split(".")[0]
+                    for name in dir(gh_token)
+                    if isinstance(getattr(gh_token, name, None), type(os))}
+        for scheduler in ("threading", "sched", "asyncio", "signal",
+                          "multiprocessing"):
+            self.assertNotIn(scheduler, imported)
+
+    def test_subprocess_is_only_used_to_sign_and_to_run_the_child(self):
+        """The only processes started are openssl and the caller's command."""
+        import inspect
+        calls = [line.strip() for line in inspect.getsource(gh_token).splitlines()
+                 if "subprocess.run(" in line]
+        self.assertEqual(len(calls), 2, calls)
 
 
 if __name__ == "__main__":

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -1,0 +1,145 @@
+"""Tests for the seed kit's least-privilege App token helper.
+
+The invariant under test is structural, not stylistic: there must be no
+way to obtain a token carrying more than the caller named, and elevated
+permissions must be impossible to request silently.
+"""
+
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+_path = pathlib.Path(__file__).resolve().parent.parent / "seed" / "scripts" / "gh_token.py"
+_spec = importlib.util.spec_from_file_location("gh_token", _path)
+gh_token = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gh_token)
+
+
+def _mint(*args, **kwargs):
+    """Call mint() with the network stubbed; return (token, captured_body)."""
+    captured = {}
+
+    def fake_api(path, bearer, method="GET", payload=None):
+        if path == "/app/installations":
+            return [{"id": 42, "account": {"login": "warblersafety"}}]
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"token": "ghs_stub", "expires_at": "2026-08-21T00:00:00Z"}
+
+    with mock.patch.object(gh_token, "api", fake_api), \
+         mock.patch.object(gh_token, "app_jwt", lambda *a, **k: "jwt-stub"):
+        result = gh_token.mint(*args, app_id="1", key_path="/dev/null", **kwargs)
+    return result, captured
+
+
+class ScopingTests(unittest.TestCase):
+    def test_token_requests_exactly_what_was_named(self):
+        (token, _), captured = _mint(
+            "warblersafety", ["scratch"], {"contents": "write"})
+        self.assertEqual(token, "ghs_stub")
+        self.assertEqual(captured["payload"]["repositories"], ["scratch"])
+        self.assertEqual(captured["payload"]["permissions"], {"contents": "write"})
+
+    def test_nothing_extra_is_added_to_the_request(self):
+        _, captured = _mint("warblersafety", ["scratch"],
+                            {"contents": "write", "issues": "write"})
+        self.assertEqual(set(captured["payload"]), {"repositories", "permissions"})
+        for elevated in gh_token.ELEVATED:
+            self.assertNotIn(elevated, captured["payload"]["permissions"])
+
+    def test_empty_repositories_is_refused(self):
+        with self.assertRaises(gh_token.TokenError) as caught:
+            _mint("warblersafety", [], {"contents": "write"})
+        self.assertIn("no repositories", str(caught.exception).lower())
+
+    def test_empty_permissions_is_refused(self):
+        with self.assertRaises(gh_token.TokenError) as caught:
+            _mint("warblersafety", ["scratch"], {})
+        self.assertIn("no permissions", str(caught.exception).lower())
+
+    def test_no_public_entry_point_mints_unscoped(self):
+        """mint() is the only way in, and both scoping args are required."""
+        import inspect
+        signature = inspect.signature(gh_token.mint)
+        for required in ("repositories", "permissions"):
+            self.assertIs(signature.parameters[required].default,
+                          inspect.Parameter.empty,
+                          f"{required} must have no default -- a default is an "
+                          f"unscoped path by another name")
+
+
+class ElevationTests(unittest.TestCase):
+    def test_elevated_permission_requires_a_reason(self):
+        for name in gh_token.ELEVATED:
+            with self.subTest(permission=name):
+                with self.assertRaises(gh_token.TokenError) as caught:
+                    _mint("warblersafety", ["scratch"], {name: "write"})
+                self.assertIn("reason", str(caught.exception).lower())
+
+    def test_blank_reason_does_not_count(self):
+        with self.assertRaises(gh_token.TokenError):
+            _mint("warblersafety", ["scratch"], {"administration": "write"},
+                  reason="   ")
+
+    def test_elevated_with_reason_is_announced_on_stderr(self):
+        stderr = io.StringIO()
+        with mock.patch.object(sys, "stderr", stderr):
+            (token, _), captured = _mint(
+                "warblersafety", ["scratch"], {"administration": "write"},
+                reason="bootstrap: apply protect-main ruleset")
+        self.assertEqual(token, "ghs_stub")
+        self.assertIn("elevated", stderr.getvalue())
+        self.assertIn("apply protect-main ruleset", stderr.getvalue())
+        self.assertNotIn(token, stderr.getvalue(),
+                         "the announcement must never carry the credential")
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_missing_key_fails_with_an_actionable_message(self):
+        with self.assertRaises(gh_token.TokenError) as caught:
+            gh_token.app_jwt("1", "/nonexistent/path/app.pem")
+        message = str(caught.exception)
+        self.assertIn("SOFA_APP_KEY", message)
+        self.assertIn("Steve's ceremony", message)
+
+    def test_missing_app_id_fails_cleanly(self):
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             self.assertRaises(gh_token.TokenError) as caught:
+            gh_token.mint("warblersafety", ["scratch"], {"contents": "write"})
+        self.assertIn("SOFA_APP_ID", str(caught.exception))
+
+    def test_unknown_account_names_the_fix(self):
+        with mock.patch.object(gh_token, "api",
+                               lambda *a, **k: [{"id": 1, "account": {"login": "other"}}]):
+            with self.assertRaises(gh_token.TokenError) as caught:
+                gh_token.installation_id("warblersafety", "jwt-stub")
+        self.assertIn("no installation", str(caught.exception).lower())
+
+    def test_id_is_never_hardcoded(self):
+        source = _path.read_text()
+        self.assertNotIn("4665307", source,
+                         "the App ID is configuration, not source")
+
+
+class NoStandingExecutionTests(unittest.TestCase):
+    def test_helper_starts_no_daemon_or_timer(self):
+        """Grant 1 is dormant: nothing here may begin work on its own."""
+        source = _path.read_text()
+        for forbidden in ("threading", "sched", "daemon", "launchd",
+                          "crontab", "LaunchAgent", "while True"):
+            self.assertNotIn(forbidden, source)
+
+    def test_no_deletion_call_site(self):
+        source = _path.read_text()
+        self.assertNotIn('"DELETE"', source)
+        self.assertNotIn("'DELETE'", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -12,6 +12,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -76,7 +77,9 @@ class ScopingTests(unittest.TestCase):
 
 class ElevationTests(unittest.TestCase):
     def test_elevated_permission_requires_a_reason(self):
-        for name in gh_token.ELEVATED:
+        repo_level = [p for p in gh_token.ELEVATED if p not in gh_token.ORG_LEVEL]
+        self.assertTrue(repo_level, "the repo-level elevated set must not be empty")
+        for name in repo_level:
             with self.subTest(permission=name):
                 with self.assertRaises(gh_token.TokenError) as caught:
                     _mint("warblersafety", ["scratch"], {name: "write"})
@@ -127,6 +130,106 @@ class ConfigurationTests(unittest.TestCase):
                          "the App ID is configuration, not source")
 
 
+class OrgLevelTests(unittest.TestCase):
+    """Org-level permissions are installation-wide; the repo list is no bound."""
+
+    def test_org_level_permission_is_refused_by_mint(self):
+        for name in gh_token.ORG_LEVEL:
+            with self.subTest(permission=name):
+                with self.assertRaises(gh_token.TokenError) as caught:
+                    _mint("warblersafety", ["scratch"], {name: "write"},
+                          reason="a reason is not enough for org-level")
+                self.assertIn("installation-wide", str(caught.exception))
+
+    def test_cli_cannot_request_org_level(self):
+        with mock.patch.object(sys, "stderr", io.StringIO()):
+            code = gh_token.main(["--account", "warblersafety", "--repos", "scratch",
+                                  "--perm", "organization_administration=write",
+                                  "--reason", "trying it on", "--", "true"])
+        self.assertEqual(code, 2)
+
+    def test_create_repo_does_not_return_the_token(self):
+        seen = {}
+
+        def fake_mint(*args, **kwargs):
+            seen["permissions"] = args[2]
+            seen["allow"] = kwargs.get("_allow_org_level")
+            return "ghs_secret", "2026-08-21T00:00:00Z"
+
+        with mock.patch.object(gh_token, "mint", fake_mint), \
+             mock.patch.object(gh_token, "api", lambda *a, **k: {"full_name": "o/r"}):
+            result = gh_token.create_repo("warblersafety", "r", reason="bootstrap")
+        self.assertEqual(result, {"full_name": "o/r"})
+        self.assertNotIn("ghs_secret", json.dumps(result))
+        self.assertTrue(seen["allow"])
+        self.assertEqual(set(seen["permissions"]),
+                         {"organization_administration", "administration"})
+
+    def test_create_repo_requires_a_reason(self):
+        with self.assertRaises(gh_token.TokenError):
+            gh_token.create_repo("warblersafety", "r", reason="")
+
+
+class AuditTests(unittest.TestCase):
+    def test_elevation_is_written_to_a_durable_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "nested" / "elevations.log"
+            gh_token.record_elevation("warblersafety", ["scratch"],
+                                      {"administration": "write"},
+                                      "bootstrap: apply protect-main",
+                                      audit_path=str(log))
+            entry = json.loads(log.read_text().strip())
+        self.assertEqual(entry["repositories"], ["scratch"])
+        self.assertEqual(entry["reason"], "bootstrap: apply protect-main")
+        self.assertIn("at", entry)
+
+    def test_record_never_contains_a_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "elevations.log"
+            gh_token.record_elevation("o", ["r"], {"administration": "write"},
+                                      "why", audit_path=str(log))
+            self.assertNotIn("ghs_", log.read_text())
+            self.assertNotIn("token", log.read_text())
+
+    def test_unwritable_audit_log_fails_closed(self):
+        """No record, no elevation -- the mint must not proceed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = pathlib.Path(tmp) / "blocked"
+            blocker.write_text("not a directory")
+            with self.assertRaises(gh_token.TokenError) as caught:
+                gh_token.record_elevation("o", ["r"], {"administration": "write"},
+                                          "why", audit_path=str(blocker / "log"))
+        self.assertIn("could not be recorded", str(caught.exception))
+
+
+class NoCredentialLeakTests(unittest.TestCase):
+    def test_there_is_no_way_to_print_a_token(self):
+        """stdout lands in a transcript on disk; the tool must not offer it."""
+        source = _path.read_text()
+        self.assertNotIn("--print", source)
+        with mock.patch.object(sys, "stderr", io.StringIO()), \
+             self.assertRaises(SystemExit):
+            gh_token.main(["--account", "o", "--repos", "r",
+                           "--perm", "contents=write"])
+
+    def test_command_runs_with_token_in_env_not_argv(self):
+        captured = {}
+
+        def fake_run(command, env=None):
+            captured["command"] = command
+            captured["env"] = env
+            return subprocess.CompletedProcess(command, 0)
+
+        with mock.patch.object(gh_token, "mint",
+                               lambda *a, **k: ("ghs_secret", "later")), \
+             mock.patch.object(gh_token.subprocess, "run", fake_run):
+            gh_token.main(["--account", "o", "--repos", "r",
+                           "--perm", "contents=write", "--", "gh", "pr", "list"])
+        self.assertEqual(captured["command"], ["gh", "pr", "list"])
+        self.assertEqual(captured["env"]["GH_TOKEN"], "ghs_secret")
+        self.assertNotIn("ghs_secret", " ".join(captured["command"]))
+
+
 class NoStandingExecutionTests(unittest.TestCase):
     def test_helper_starts_no_daemon_or_timer(self):
         """Grant 1 is dormant: nothing here may begin work on its own."""
@@ -134,11 +237,6 @@ class NoStandingExecutionTests(unittest.TestCase):
         for forbidden in ("threading", "sched", "daemon", "launchd",
                           "crontab", "LaunchAgent", "while True"):
             self.assertNotIn(forbidden, source)
-
-    def test_no_deletion_call_site(self):
-        source = _path.read_text()
-        self.assertNotIn('"DELETE"', source)
-        self.assertNotIn("'DELETE'", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why this change

Issue #20, this session. The fine-grained PAT hit two capability walls in the sofa-scratch round-two bootstrap: repo administration 403'd, forcing a manual Steve step into every bootstrap, and the checks layer was unreadable on private repos, which forced `merge_dev.py` onto the Actions API as a workaround. Steve decided the GitHub App replaces the PAT outright — one mechanism, not two — and granted it **organization-level Administration** on `warblersafety`, knowingly moving its ceiling from per-repo to org-wide.

That widening is the incident this PR answers. An App that can administer an org can, in principle, delete its repositories and change its membership. Least-privilege minting is the control that keeps the *working* credential far below that ceiling, so it ships before anything starts depending on the App. A rule whose enforcement is unwritten is prose, not a rail (decisions/0001) — which is why the grant and the helper travel in one PR rather than two.

Closes #21.

## What changed

**`governance/grants.md` — Grant 4.** The App supersedes the PAT. Least privilege is the only mint path; elevation is confined to bootstrap's two call sites and must state a reason; no token is written to disk or left in `GH_TOKEN` between commands. The grant names the org-admin widening explicitly rather than glossing it, and records that deletion cannot be split off from `administration` — so the honest claim is that admin reach is *bounded by scoping*, not absent.

**`seed/scripts/gh_token.py`.** `mint()` requires both a repository list and a permission map, with no defaults — a default would be an unscoped path by another name. Requesting `administration` or `organization_administration` without a reason is refused; with one, the elevation is echoed to stderr so a transcript shows it. `--exec` sets `GH_TOKEN` for one child process only, so the token never reaches stdout or a shell variable that outlives the command; `--print` exists but must be asked for.

**`tests/test_gh_token.py`.** 17 tests covering the structural invariants, including one asserting `mint()`'s scoping parameters have no defaults, and one asserting the App ID never appears in source.

Two findings worth carrying forward, both established by API test rather than inference:

- Repo creation needs **both** `organization_administration:write` and repo-level `administration:write` — determined without creating or deleting anything, by attempting creation with a name that already exists (`403` = insufficient, `422` = sufficient).
- A token cannot be scoped to *zero* repositories: `repositories: []` is silently treated as all, and a nonexistent name or id is rejected `422`. Hence creation tokens scope to the throwaway scratch repo rather than minting unscoped.

## Verification

`python3 -m unittest discover -s tests` — 27 tests, all passing.

Live against the real App (`warblersafety/scratch`), not only mocks:

| check | result |
|---|---|
| scoped `--exec`, contents-only token running `gh repo view` | `warblersafety/scratch  default=dev` |
| elevated without `--reason` | refused, exit 2, nothing minted |
| elevated with `--reason`, reading rulesets | announced on stderr; `protect-main, protect-staging` |
| empty repository list | refused, exit 2 |
| missing private key | actionable message naming `SOFA_APP_KEY`, exit 2 |

## Review

Governance prose, so the adversarial doc-review is the first line. **Brief, visible before it runs:**

1. Does Grant 4 overstate the protection? Specifically: it claims scoped minting keeps the working credential below the App's ceiling — is that true of every path in `gh_token.py`, or only the ones the tests exercise?
2. Is the org-admin widening described honestly enough that a reader six months from now understands what Steve actually granted, without needing this conversation?
3. Does the grant conflict with Grant 1's dormancy, or with the account rule that credential ceremonies are Steve's?
4. Is "deletion has no call site" a claim the code can keep, or does it depend on future authors not adding one?
5. Does anything in the grant require a convention a bootstrapped repo lacks?

Hard caps per the skill: findings are triaged by the intake rule; anything below the noise floor is not filed.