### PR TITLE
Remove the PAT from tooling and the seed kit

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -31,6 +31,9 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `seed/pull_request_template.md` → `.github/pull_request_template.md`,
    `seed/ISSUE_TEMPLATE/unit.yml` → `.github/ISSUE_TEMPLATE/unit.yml`,
    `seed/ISSUE_TEMPLATE/config.yml` → `.github/ISSUE_TEMPLATE/config.yml`,
+   `seed/scripts/gh_token.py` → `scripts/gh_token.py` (the repo's only
+   credential path; `merge_dev.py` imports it from alongside itself and
+   stops rather than falling back to ambient auth if it is absent),
    `seed/scripts/merge_dev.py` → `scripts/merge_dev.py` (align its
    `REQUIRED_CHECKS` with the workload ci.yml's job names, and keep its
    executable bit — mode `100755`, so the shebang stays honest and a lint

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -94,7 +94,18 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `backlog-expiry.yml`, `pull_request_template.md`, both issue templates
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
-   names, its executable bit intact) are all present;
+   names, its executable bit intact) and `scripts/gh_token.py` are all
+   present; **the credential path actually works** — mint a read-only
+   token for this repo and run one `gh` call under it, because the file
+   being present proves nothing about the repo being inside the App's
+   installation. A personal-account installation is scoped to selected
+   repositories and a new repo is **not** added automatically; adding it
+   needs a user-to-server token, so it is Steve's ceremony, not Claude's.
+   A mint that fails here means the first unit will reach a green PR and
+   then be unable to merge, so it is a needs-Steve digest entry with the
+   exact step (App → Install → this repo), never a silent pass. An
+   org installation set to *All repositories* covers new repos
+   automatically — confirm which of the two applies and record it;
    **no seed placeholder survives** in any copied file — grep for `{{`
    and discard only `${{` (GitHub Actions expressions, which are
    legitimate and permanent). Do not narrow this to `{{[A-Z_]\+}}`: the

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -31,9 +31,11 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    `seed/pull_request_template.md` → `.github/pull_request_template.md`,
    `seed/ISSUE_TEMPLATE/unit.yml` → `.github/ISSUE_TEMPLATE/unit.yml`,
    `seed/ISSUE_TEMPLATE/config.yml` → `.github/ISSUE_TEMPLATE/config.yml`,
-   `seed/scripts/gh_token.py` → `scripts/gh_token.py` (the repo's only
-   credential path; `merge_dev.py` imports it from alongside itself and
-   stops rather than falling back to ambient auth if it is absent),
+   `seed/scripts/gh_token.py` → `scripts/gh_token.py` (the credential
+   path for scripted access; `merge_dev.py` imports it from alongside
+   itself and stops rather than falling back to ambient auth if it is
+   absent — keep its executable bit, mode `100755`, since it has a
+   shebang and step 6 invokes it directly),
    `seed/scripts/merge_dev.py` → `scripts/merge_dev.py` (align its
    `REQUIRED_CHECKS` with the workload ci.yml's job names, and keep its
    executable bit — mode `100755`, so the shebang stays honest and a lint

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -44,6 +44,10 @@ refreshes it.
   available on private repos at this plan — do not rely on it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
+- GitHub credentials come from `scripts/gh_token.py` — a short-lived App
+  token scoped to this repo and to the permissions the task needs. There
+  is no PAT and no ambient `GH_TOKEN`; if minting fails, work stops
+  rather than reaching for another credential.
 - Promote often: a `dev` far ahead of `staging` makes promotion scary
   instead of routine. Claude flags when the gap exceeds ~10 units.
 

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -45,9 +45,10 @@ refreshes it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
 - GitHub credentials come from `scripts/gh_token.py` — a short-lived App
-  token scoped to this repo and to the permissions the task needs. There
-  is no PAT and no ambient `GH_TOKEN`; if minting fails, work stops
-  rather than reaching for another credential.
+  token scoped to this repo and to the permissions the task needs. If
+  minting fails, work stops and the cause goes to the needs-Steve digest;
+  never retry under whatever credential the environment happens to carry,
+  and never `gh auth login`. This repo requires no PAT of its own.
 - Promote often: a `dev` far ahead of `staging` makes promotion scary
   instead of routine. Claude flags when the gap exceeds ~10 units.
 

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -44,11 +44,13 @@ refreshes it.
   available on private repos at this plan — do not rely on it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
-- GitHub credentials come from `scripts/gh_token.py` — a short-lived App
-  token scoped to this repo and to the permissions the task needs. If
-  minting fails, work stops and the cause goes to the needs-Steve digest;
-  never retry under whatever credential the environment happens to carry,
-  and never `gh auth login`. This repo requires no PAT of its own.
+- Scripted GitHub access — `scripts/merge_dev.py` today — takes its
+  credential from `scripts/gh_token.py`: a short-lived App token scoped to
+  this repo and to the permissions that task needs. If minting fails, that
+  work stops and the cause goes to the needs-Steve digest; never retry
+  under another credential, and never `gh auth login`. Interactive `gh`
+  still runs on the session's ambient auth until sofa-claude #23 lands.
+  This repo requires no PAT of its own.
 - Promote often: a `dev` far ahead of `staging` makes promotion scary
   instead of routine. Claude flags when the gap exceeds ~10 units.
 

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -245,8 +245,22 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
         raise TokenError("SOFA_APP_ID is not set; it is the App's numeric ID.")
     key_path = key_path or os.environ.get("SOFA_APP_KEY") or DEFAULT_KEY
     if recorded:
-        entry = record_elevation(account, repositories, permissions, reason or "")
-        if elevated:
+        # Fail closed only where the control actually lives: an *elevation*
+        # must not happen unrecorded. A read-level record is forensic, and
+        # letting an unwritable log turn every routine merge into a
+        # credential failure would be a far larger outage than the gap it
+        # closes -- so that case warns loudly and proceeds.
+        try:
+            entry = record_elevation(account, repositories, permissions,
+                                     reason or "")
+        except TokenError:
+            if elevated:
+                raise
+            print("[gh_token] WARNING: could not record a read-level mint; "
+                  "proceeding. Elevated mints would refuse here.",
+                  file=sys.stderr)
+            entry = None
+        if elevated and entry:
             print(f"[gh_token] elevated ({', '.join(elevated)}) recorded: "
                   f"{entry['reason']}", file=sys.stderr)
     jwt = app_jwt(app_id, key_path)
@@ -254,8 +268,12 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
                  jwt, "POST",
                  {"repositories": list(repositories), "permissions": dict(permissions)})
     if recorded:
-        record_elevation(account, repositories, permissions, reason or "",
-                         event="granted")
+        try:
+            record_elevation(account, repositories, permissions, reason or "",
+                             event="granted")
+        except TokenError:
+            if elevated:
+                raise
     return result["token"], result.get("expires_at")
 
 

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -24,9 +24,15 @@ Two limits are worth stating because they are counter-intuitive:
 
 Elevated permissions require a stated reason and append an audit record.
 If the record cannot be written, nothing is minted: no record, no
-elevation. There is deliberately no way to print a token to stdout --
-in this environment stdout lands in a transcript on disk and in model
-context, where it would outlive the command that needed it.
+elevation.
+
+This tool never prints a token itself -- in this environment stdout lands
+in a transcript on disk and in model context, where it would outlive the
+command that needed it. It cannot stop the command it runs from printing
+one: the child receives the token in its environment, so `-- env` or
+`-- gh auth token` would expose it. That is a limit of handing a
+credential to a child process at all, not something a flag removes. Do
+not use this tool to dump an environment.
 
 Configuration (no value is ever hardcoded):
     SOFA_APP_ID     the App's numeric ID
@@ -59,21 +65,30 @@ DEFAULT_AUDIT = "~/.config/sofa-claude/elevations.log"
 ORG_LEVEL = ("organization_administration", "members", "organization_secrets",
              "organization_projects", "organization_hooks",
              "organization_self_hosted_runners", "organization_user_blocking")
-# Requesting any of these AT WRITE LEVEL requires a reason and leaves an
-# audit record. `administration` carries deletion AND ruleset removal;
-# `secrets`, `actions` and `workflows` can install or feed code that runs
-# with them. Read level is not elevation: `actions=read` is what an
-# ordinary CI check needs, and recording it would bury the writes that
-# matter in noise -- the audit log is a detection control, and a control
-# no one can read is not one.
+# Every mint naming one of these is recorded, at any level: `actions:read`
+# is log and artifact access, `secrets:read` enumerates a secret
+# inventory, and the audit log is Grant 4's detection control -- narrowing
+# what it sees to save a few lines a day is a bad trade. A *reason* is
+# demanded only for the write levels, so routine CI reads stay frictionless
+# while the trail stays intact; a reader wanting only writes can filter the
+# recorded permissions dict.
 ELEVATED = ORG_LEVEL + ("administration", "secrets", "actions", "workflows")
-WRITE_LEVELS = ("write", "admin")
+# Deny-by-default, like every other refusal here: anything that is not
+# exactly `read` counts as a write. An allowlist of write levels would let
+# an unanticipated value ("true", a level GitHub adds later) fall through
+# as harmless on the one permission that can remove a ruleset.
+READ_LEVEL = "read"
+
+
+def recorded_permissions(permissions):
+    """Names worth an audit record -- any level."""
+    return sorted(name for name in permissions if name in ELEVATED)
 
 
 def elevated_permissions(permissions):
-    """Names in `permissions` that are elevated at the level requested."""
+    """Names that additionally require a stated reason (write levels)."""
     return sorted(name for name, level in permissions.items()
-                  if name in ELEVATED and str(level).lower() in WRITE_LEVELS)
+                  if name in ELEVATED and str(level).strip().lower() != READ_LEVEL)
 
 
 class TokenError(RuntimeError):
@@ -129,6 +144,13 @@ def api(path, bearer, method="GET", payload=None):
         except Exception:
             pass
         raise TokenError(f"GitHub {err.code} on {method} {path}: {detail}")
+    except urllib.error.URLError as err:
+        # DNS, offline, TLS. Must surface as TokenError like any other
+        # credential failure: a traceback escaping here would reach the
+        # caller as an unhandled crash rather than a loud, typed refusal.
+        raise TokenError(f"Cannot reach GitHub for {method} {path}: {err.reason}")
+    except ValueError as err:
+        raise TokenError(f"Unparseable response from {method} {path}: {err}")
 
 
 def installation_id(account, jwt):
@@ -210,6 +232,7 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
             f"repository list, so there is no such thing as a scoped one. "
             f"They are reachable only through create_repo(), which mints and "
             f"discards internally (Grant 4).")
+    recorded = recorded_permissions(permissions)
     elevated = elevated_permissions(permissions)
     if elevated and not (reason or "").strip():
         raise TokenError(
@@ -221,16 +244,17 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
     if not app_id:
         raise TokenError("SOFA_APP_ID is not set; it is the App's numeric ID.")
     key_path = key_path or os.environ.get("SOFA_APP_KEY") or DEFAULT_KEY
-    if elevated:
-        entry = record_elevation(account, repositories, permissions, reason)
-        print(f"[gh_token] elevated ({', '.join(elevated)}) recorded: "
-              f"{entry['reason']}", file=sys.stderr)
+    if recorded:
+        entry = record_elevation(account, repositories, permissions, reason or "")
+        if elevated:
+            print(f"[gh_token] elevated ({', '.join(elevated)}) recorded: "
+                  f"{entry['reason']}", file=sys.stderr)
     jwt = app_jwt(app_id, key_path)
     result = api(f"/app/installations/{installation_id(account, jwt)}/access_tokens",
                  jwt, "POST",
                  {"repositories": list(repositories), "permissions": dict(permissions)})
-    if elevated:
-        record_elevation(account, repositories, permissions, reason,
+    if recorded:
+        record_elevation(account, repositories, permissions, reason or "",
                          event="granted")
     return result["token"], result.get("expires_at")
 

--- a/seed/scripts/gh_token.py
+++ b/seed/scripts/gh_token.py
@@ -59,10 +59,21 @@ DEFAULT_AUDIT = "~/.config/sofa-claude/elevations.log"
 ORG_LEVEL = ("organization_administration", "members", "organization_secrets",
              "organization_projects", "organization_hooks",
              "organization_self_hosted_runners", "organization_user_blocking")
-# Requesting any of these requires a reason and leaves an audit record.
-# `administration` carries deletion AND ruleset removal; `secrets`,
-# `actions` and `workflows` can install or feed code that runs with them.
+# Requesting any of these AT WRITE LEVEL requires a reason and leaves an
+# audit record. `administration` carries deletion AND ruleset removal;
+# `secrets`, `actions` and `workflows` can install or feed code that runs
+# with them. Read level is not elevation: `actions=read` is what an
+# ordinary CI check needs, and recording it would bury the writes that
+# matter in noise -- the audit log is a detection control, and a control
+# no one can read is not one.
 ELEVATED = ORG_LEVEL + ("administration", "secrets", "actions", "workflows")
+WRITE_LEVELS = ("write", "admin")
+
+
+def elevated_permissions(permissions):
+    """Names in `permissions` that are elevated at the level requested."""
+    return sorted(name for name, level in permissions.items()
+                  if name in ELEVATED and str(level).lower() in WRITE_LEVELS)
 
 
 class TokenError(RuntimeError):
@@ -199,7 +210,7 @@ def mint(account, repositories, permissions, reason=None, app_id=None,
             f"repository list, so there is no such thing as a scoped one. "
             f"They are reachable only through create_repo(), which mints and "
             f"discards internally (Grant 4).")
-    elevated = sorted(p for p in permissions if p in ELEVATED)
+    elevated = elevated_permissions(permissions)
     if elevated and not (reason or "").strip():
         raise TokenError(
             f"Refusing to mint {', '.join(elevated)} without a stated reason. "

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -11,10 +11,12 @@ On transport failure it says so and stops: do NOT merge by hand as a
 workaround — fix the cause or put it in the needs-Steve digest.
 
 Credentials come from the App via scripts/gh_token.py, scoped to this
-repository and to the permissions a merge actually needs. If the App is
-not configured the script stops: it never falls back to ambient auth,
+repository and to the permissions a merge actually needs. If minting
+fails, this script stops at exit 4 without calling `gh` at all — it does
+not retry under whatever credential the environment happens to carry,
 because a silent fallback is how a broad standing token survives a
-migration meant to remove it (governance/grants.md, Grant 4).
+migration meant to remove it (governance/grants.md, Grant 4). It cannot
+scrub the environment it runs in; what it guarantees is its own conduct.
 
 Usage: python3 scripts/merge_dev.py <PR-number>
 """
@@ -39,6 +41,14 @@ MERGE_PERMISSIONS = {
     "actions": "read",
     "metadata": "read",
 }
+# NOT included: `statuses`. statusCheckRollup also returns StatusContext
+# nodes — commit statuses, which is what a Vercel preview posts — and
+# those are read under a separate Commit statuses permission the App has
+# not been granted (requesting it 422s the whole mint). Until it is
+# granted, a repo whose CI posts commit statuses may see them missing
+# from the rollup, and a missing check is not evaluated as a blocker.
+# Tracked in sofa-claude Issue #26; REQUIRED_CHECKS still catches an
+# absent required check, which is the case that matters most.
 
 
 def _gh_token_module():
@@ -142,9 +152,13 @@ def main(argv):
         owner, repo = _origin()
         gh_token = _gh_token_module()
         token, _ = gh_token.mint(owner, [repo], MERGE_PERMISSIONS)
-    except (RuntimeError, subprocess.CalledProcessError) as err:
-        # gh_token.TokenError subclasses RuntimeError, so this covers a
-        # missing key, an uninstalled App, and an unparseable remote alike.
+    except Exception as err:
+        # Deliberately broad, and it must stay that way: exit 4 is the
+        # "nothing was merged, and not because the PR was blocked" signal.
+        # A traceback escaping here would exit 1 — the same status as a
+        # legitimate refusal — so an unattended run could not tell a
+        # network blip from a blocked PR, and none of the text below
+        # would print.
         print("CREDENTIAL FAILURE — nothing was merged.")
         print(str(err))
         print("Do NOT merge by hand as a workaround, and do not fall back to "

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -10,12 +10,61 @@ why merging any other way is declared a defect in CLAUDE.md.
 On transport failure it says so and stops: do NOT merge by hand as a
 workaround — fix the cause or put it in the needs-Steve digest.
 
+Credentials come from the App via scripts/gh_token.py, scoped to this
+repository and to the permissions a merge actually needs. If the App is
+not configured the script stops: it never falls back to ambient auth,
+because a silent fallback is how a broad standing token survives a
+migration meant to remove it (governance/grants.md, Grant 4).
+
 Usage: python3 scripts/merge_dev.py <PR-number>
 """
 
+import importlib.util
 import json
+import os
+import pathlib
+import re
 import subprocess
 import sys
+
+# `gh pr view --json statusCheckRollup` resolves each check's workflow
+# run, which needs actions:read — verified against a private repo, where
+# omitting it fails with "Resource not accessible by integration" rather
+# than returning a partial rollup. Read level throughout except the two
+# writes the merge itself performs.
+MERGE_PERMISSIONS = {
+    "contents": "write",       # squash-merge, delete the branch
+    "pull_requests": "write",  # perform the merge; read the comments
+    "checks": "read",
+    "actions": "read",
+    "metadata": "read",
+}
+
+
+def _gh_token_module():
+    path = pathlib.Path(__file__).resolve().parent / "gh_token.py"
+    if not path.exists():
+        raise RuntimeError(
+            f"{path} is missing. It is the only sanctioned credential path; "
+            f"bootstrap copies it alongside this script.")
+    spec = importlib.util.spec_from_file_location("gh_token", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def repo_slug(remote_url):
+    """(owner, repo) from a git remote URL, SSH or HTTPS."""
+    match = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?/?$", remote_url.strip())
+    if not match:
+        raise RuntimeError(f"Cannot parse an owner/repo out of {remote_url!r}.")
+    return match.group(1), match.group(2)
+
+
+def _origin():
+    url = subprocess.run(["git", "remote", "get-url", "origin"],
+                         check=True, capture_output=True, text=True).stdout
+    return repo_slug(url)
 
 REVIEW_MARKER = "## Reviewer pass"
 # Bootstrap aligns these with the workload ci.yml's actual job names.
@@ -69,9 +118,9 @@ def evaluate(pr, comment_bodies):
     return blockers
 
 
-def _gh(args):
+def _gh(args, env):
     return subprocess.run(["gh"] + args, check=True, capture_output=True,
-                          text=True).stdout
+                          text=True, env=env).stdout
 
 
 def _transport_failure(err):
@@ -90,9 +139,23 @@ def main(argv):
         return 2
     number = argv[1]
     try:
+        owner, repo = _origin()
+        gh_token = _gh_token_module()
+        token, _ = gh_token.mint(owner, [repo], MERGE_PERMISSIONS)
+    except (RuntimeError, subprocess.CalledProcessError) as err:
+        # gh_token.TokenError subclasses RuntimeError, so this covers a
+        # missing key, an uninstalled App, and an unparseable remote alike.
+        print("CREDENTIAL FAILURE — nothing was merged.")
+        print(str(err))
+        print("Do NOT merge by hand as a workaround, and do not fall back to "
+              "another credential — fix the cause or put it in the "
+              "needs-Steve digest.")
+        return 4
+    env = dict(os.environ, GH_TOKEN=token, GITHUB_TOKEN=token)
+    try:
         fields = ("isDraft,state,baseRefName,headRefName,"
                   "statusCheckRollup,comments")
-        pr = json.loads(_gh(["pr", "view", number, "--json", fields]))
+        pr = json.loads(_gh(["pr", "view", number, "--json", fields], env))
     except subprocess.CalledProcessError as err:
         return _transport_failure(err)
     bodies = [c.get("body", "") for c in pr.get("comments") or []]
@@ -103,7 +166,7 @@ def main(argv):
             print(f"  - {b}")
         return 1
     try:
-        _gh(["pr", "merge", number, "--squash", "--delete-branch"])
+        _gh(["pr", "merge", number, "--squash", "--delete-branch"], env)
     except subprocess.CalledProcessError as err:
         return _transport_failure(err)
     print(f"Merged PR #{number} to dev (squash) and deleted its branch.")

--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -34,13 +34,20 @@ import sys
 # omitting it fails with "Resource not accessible by integration" rather
 # than returning a partial rollup. Read level throughout except the two
 # writes the merge itself performs.
-MERGE_PERMISSIONS = {
-    "contents": "write",       # squash-merge, delete the branch
-    "pull_requests": "write",  # perform the merge; read the comments
+# Two phases, deliberately. Reading a PR to decide whether it may merge
+# needs nothing writable, so a refused PR never has a merge-capable
+# credential in the room at all. The write token is minted only once
+# `evaluate()` has returned no blockers.
+INSPECT_PERMISSIONS = {
+    "pull_requests": "read",   # the PR, and its comments
     "checks": "read",
-    "actions": "read",
+    "actions": "read",         # statusCheckRollup resolves workflow runs
+    "contents": "read",
     "metadata": "read",
 }
+MERGE_PERMISSIONS = dict(INSPECT_PERMISSIONS,
+                         contents="write",       # squash-merge, delete branch
+                         pull_requests="write")  # perform the merge
 # NOT included: `statuses`. statusCheckRollup also returns StatusContext
 # nodes — commit statuses, which is what a Vercel preview posts — and
 # those are read under a separate Commit statuses permission the App has
@@ -151,7 +158,7 @@ def main(argv):
     try:
         owner, repo = _origin()
         gh_token = _gh_token_module()
-        token, _ = gh_token.mint(owner, [repo], MERGE_PERMISSIONS)
+        token, _ = gh_token.mint(owner, [repo], INSPECT_PERMISSIONS)
     except Exception as err:
         # Deliberately broad, and it must stay that way: exit 4 is the
         # "nothing was merged, and not because the PR was blocked" signal.
@@ -179,6 +186,16 @@ def main(argv):
         for b in blockers:
             print(f"  - {b}")
         return 1
+    try:
+        token, _ = gh_token.mint(owner, [repo], MERGE_PERMISSIONS)
+    except Exception as err:
+        print("CREDENTIAL FAILURE — nothing was merged.")
+        print(str(err))
+        print("Do NOT merge by hand as a workaround, and do not fall back to "
+              "another credential — fix the cause or put it in the "
+              "needs-Steve digest.")
+        return 4
+    env = dict(os.environ, GH_TOKEN=token, GITHUB_TOKEN=token)
     try:
         _gh(["pr", "merge", number, "--squash", "--delete-branch"], env)
     except subprocess.CalledProcessError as err:

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -23,7 +23,13 @@ _spec.loader.exec_module(gh_token)
 
 
 def _mint(*args, **kwargs):
-    """Call mint() with the network stubbed; return (token, captured_body)."""
+    """Call mint() with the network stubbed; return (token, captured_body).
+
+    SOFA_AUDIT_LOG is pinned to a temporary file: the real log is Grant 4's
+    detection control, and a test suite forging entries into it is worse
+    than a normal hygiene slip. It also keeps the suite runnable where
+    $HOME is not writable.
+    """
     captured = {}
 
     def fake_api(path, bearer, method="GET", payload=None):
@@ -33,9 +39,12 @@ def _mint(*args, **kwargs):
         captured["payload"] = payload
         return {"token": "ghs_stub", "expires_at": "2026-08-21T00:00:00Z"}
 
-    with mock.patch.object(gh_token, "api", fake_api), \
-         mock.patch.object(gh_token, "app_jwt", lambda *a, **k: "jwt-stub"):
-        result = gh_token.mint(*args, app_id="1", key_path="/dev/null", **kwargs)
+    with tempfile.TemporaryDirectory() as tmp:
+        with mock.patch.dict(os.environ,
+                             {"SOFA_AUDIT_LOG": str(pathlib.Path(tmp) / "log")}), \
+             mock.patch.object(gh_token, "api", fake_api), \
+             mock.patch.object(gh_token, "app_jwt", lambda *a, **k: "jwt-stub"):
+            result = gh_token.mint(*args, app_id="1", key_path="/dev/null", **kwargs)
     return result, captured
 
 
@@ -274,6 +283,38 @@ class AuditTests(unittest.TestCase):
                 gh_token.record_elevation("o", ["r"], {"administration": "write"},
                                           "why", audit_path=str(blocker / "log"))
         self.assertIn("could not be recorded", str(caught.exception))
+
+
+class FailClosedScopeTests(unittest.TestCase):
+    """Fail closed where the control lives; do not outage routine work."""
+
+    def _mint_with_unwritable_log(self, permissions, reason=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            blocker = pathlib.Path(tmp) / "blocked"
+            blocker.write_text("not a directory")
+            with mock.patch.dict(os.environ,
+                                 {"SOFA_AUDIT_LOG": str(blocker / "log")}), \
+                 mock.patch.object(sys, "stderr", io.StringIO()) as err, \
+                 mock.patch.object(gh_token, "app_jwt", lambda *a, **k: "jwt"), \
+                 mock.patch.object(
+                     gh_token, "api",
+                     lambda path, *a, **k: (
+                         [{"id": 1, "account": {"login": "o"}}]
+                         if path.startswith("/app/installations?")
+                         else {"token": "ghs_stub", "expires_at": "later"})):
+                return gh_token.mint("o", ["r"], permissions, reason=reason,
+                                     app_id="1", key_path="/dev/null"), err.getvalue()
+
+    def test_elevated_mint_refuses_when_it_cannot_be_recorded(self):
+        with self.assertRaises(gh_token.TokenError):
+            self._mint_with_unwritable_log({"administration": "write"},
+                                           reason="wiring")
+
+    def test_read_level_mint_warns_but_proceeds(self):
+        """An unwritable log must not turn every routine merge into a failure."""
+        (token, _), stderr = self._mint_with_unwritable_log({"actions": "read"})
+        self.assertEqual(token, "ghs_stub")
+        self.assertIn("WARNING", stderr)
 
 
 class NoCredentialLeakTests(unittest.TestCase):

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -76,7 +76,7 @@ class ScopingTests(unittest.TestCase):
 
 
 class ElevationTests(unittest.TestCase):
-    def test_read_level_is_not_elevation(self):
+    def test_read_level_needs_no_reason(self):
         """`actions=read` is what an ordinary CI check needs."""
         self.assertEqual(gh_token.elevated_permissions({"actions": "read"}), [])
         self.assertEqual(gh_token.elevated_permissions({"administration": "read"}), [])
@@ -84,9 +84,25 @@ class ElevationTests(unittest.TestCase):
                               {"actions": "read", "checks": "read"})
         self.assertEqual(token, "ghs_stub")
 
-    def test_write_level_of_the_same_permission_is_elevation(self):
-        self.assertEqual(gh_token.elevated_permissions({"actions": "write"}),
+    def test_read_level_is_still_recorded(self):
+        """Narrowing the audit trail would narrow the detection control."""
+        self.assertEqual(gh_token.recorded_permissions({"actions": "read"}),
                          ["actions"])
+        self.assertEqual(gh_token.recorded_permissions({"contents": "write"}), [])
+
+    def test_unknown_level_counts_as_a_write(self):
+        """Deny-by-default: only the exact string `read` is not elevation."""
+        for level in ("write", "admin", True, "WRITE", "true", "", None, "rw"):
+            with self.subTest(level=level):
+                self.assertEqual(
+                    gh_token.elevated_permissions({"administration": level}),
+                    ["administration"])
+
+    def test_read_is_matched_case_and_space_insensitively(self):
+        for level in ("read", "READ", " read "):
+            with self.subTest(level=level):
+                self.assertEqual(
+                    gh_token.elevated_permissions({"actions": level}), [])
 
     def test_elevated_permission_requires_a_reason(self):
         repo_level = [p for p in gh_token.ELEVATED if p not in gh_token.ORG_LEVEL]
@@ -113,6 +129,29 @@ class ElevationTests(unittest.TestCase):
         self.assertIn("apply protect-main ruleset", stderr.getvalue())
         self.assertNotIn(token, stderr.getvalue(),
                          "the announcement must never carry the credential")
+
+
+class TransportTests(unittest.TestCase):
+    """Network failures must surface as TokenError, never as a traceback."""
+
+    def test_unreachable_github_becomes_a_token_error(self):
+        import urllib.error
+        with mock.patch.object(gh_token.urllib.request, "urlopen",
+                               side_effect=urllib.error.URLError("offline")):
+            with self.assertRaises(gh_token.TokenError) as caught:
+                gh_token.api("/app", "jwt-stub")
+        self.assertIn("Cannot reach GitHub", str(caught.exception))
+
+    def test_unparseable_response_becomes_a_token_error(self):
+        class FakeResponse:
+            def read(self): return b"<html>not json</html>"
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        with mock.patch.object(gh_token.urllib.request, "urlopen",
+                               return_value=FakeResponse()):
+            with self.assertRaises(gh_token.TokenError) as caught:
+                gh_token.api("/app", "jwt-stub")
+        self.assertIn("Unparseable response", str(caught.exception))
 
 
 class ConfigurationTests(unittest.TestCase):

--- a/tests/test_gh_token.py
+++ b/tests/test_gh_token.py
@@ -76,6 +76,18 @@ class ScopingTests(unittest.TestCase):
 
 
 class ElevationTests(unittest.TestCase):
+    def test_read_level_is_not_elevation(self):
+        """`actions=read` is what an ordinary CI check needs."""
+        self.assertEqual(gh_token.elevated_permissions({"actions": "read"}), [])
+        self.assertEqual(gh_token.elevated_permissions({"administration": "read"}), [])
+        (token, _), _ = _mint("warblersafety", ["scratch"],
+                              {"actions": "read", "checks": "read"})
+        self.assertEqual(token, "ghs_stub")
+
+    def test_write_level_of_the_same_permission_is_elevation(self):
+        self.assertEqual(gh_token.elevated_permissions({"actions": "write"}),
+                         ["actions"])
+
     def test_elevated_permission_requires_a_reason(self):
         repo_level = [p for p in gh_token.ELEVATED if p not in gh_token.ORG_LEVEL]
         self.assertTrue(repo_level, "the repo-level elevated set must not be empty")

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -90,10 +90,76 @@ class EvaluateTests(unittest.TestCase):
         self.assertEqual(len(blockers), 6)
 
 
+class RepoSlugTests(unittest.TestCase):
+    def test_parses_ssh_and_https_remotes(self):
+        for url in ("git@github.com:warblersafety/wilson.git",
+                    "https://github.com/warblersafety/wilson.git",
+                    "https://github.com/warblersafety/wilson",
+                    "ssh://git@github.com/warblersafety/wilson.git\n"):
+            with self.subTest(url=url):
+                self.assertEqual(merge_dev.repo_slug(url),
+                                 ("warblersafety", "wilson"))
+
+    def test_unparseable_remote_is_refused(self):
+        with self.assertRaises(RuntimeError):
+            merge_dev.repo_slug("not-a-remote")
+
+
+class CredentialTests(unittest.TestCase):
+    """No silent fallback: if the App cannot mint, nothing merges."""
+
+    def test_permissions_are_least_privilege(self):
+        perms = merge_dev.MERGE_PERMISSIONS
+        self.assertEqual(perms["contents"], "write")
+        self.assertEqual(perms["pull_requests"], "write")
+        # statusCheckRollup resolves workflow runs; read, never write.
+        self.assertEqual(perms["actions"], "read")
+        self.assertEqual(perms["checks"], "read")
+        for name, level in perms.items():
+            self.assertIn(level, ("read", "write"))
+        self.assertNotIn("administration", perms)
+
+    def test_scoped_to_this_repository_only(self):
+        seen = {}
+
+        def fake_mint(account, repositories, permissions, **kwargs):
+            seen.update(account=account, repositories=repositories)
+            return "ghs_stub", "later"
+
+        module = mock.Mock(mint=fake_mint)
+        with mock.patch.object(merge_dev, "_origin",
+                               return_value=("warblersafety", "wilson")), \
+             mock.patch.object(merge_dev, "_gh_token_module", return_value=module), \
+             mock.patch.object(merge_dev, "_gh",
+                               side_effect=subprocess.CalledProcessError(1, ["gh"])), \
+             mock.patch("builtins.print"):
+            merge_dev.main(["merge_dev.py", "12"])
+        self.assertEqual(seen["account"], "warblersafety")
+        self.assertEqual(seen["repositories"], ["wilson"])
+
+    def test_credential_failure_stops_without_merging(self):
+        module = mock.Mock()
+        module.mint.side_effect = RuntimeError("no key on this machine")
+        with mock.patch.object(merge_dev, "_origin",
+                               return_value=("o", "r")), \
+             mock.patch.object(merge_dev, "_gh_token_module", return_value=module), \
+             mock.patch.object(merge_dev, "_gh") as fake_gh, \
+             mock.patch("builtins.print") as fake_print:
+            self.assertEqual(merge_dev.main(["merge_dev.py", "12"]), 4)
+        fake_gh.assert_not_called()
+        printed = " ".join(str(c.args[0]) for c in fake_print.call_args_list)
+        self.assertIn("CREDENTIAL FAILURE", printed)
+        self.assertIn("no key on this machine", printed)
+        self.assertIn("do not fall back to another credential", printed)
+
+
 class TransportTests(unittest.TestCase):
     def test_transport_failure_is_loud_and_does_not_merge(self):
         err = subprocess.CalledProcessError(1, ["gh"], stderr="boom")
-        with mock.patch.object(merge_dev, "_gh", side_effect=err):
+        module = mock.Mock(mint=mock.Mock(return_value=("ghs_stub", "later")))
+        with mock.patch.object(merge_dev, "_origin", return_value=("o", "r")), \
+             mock.patch.object(merge_dev, "_gh_token_module", return_value=module), \
+             mock.patch.object(merge_dev, "_gh", side_effect=err):
             with mock.patch("builtins.print") as fake_print:
                 self.assertEqual(merge_dev.main(["merge_dev.py", "12"]), 3)
         printed = " ".join(str(c.args[0]) for c in fake_print.call_args_list)

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -137,6 +137,22 @@ class CredentialTests(unittest.TestCase):
         self.assertEqual(seen["account"], "warblersafety")
         self.assertEqual(seen["repositories"], ["wilson"])
 
+    def test_any_credential_exception_yields_exit_4_not_1(self):
+        """Exit 1 means 'PR blocked'; a transport blip must not look like one."""
+        for boom in (RuntimeError("no key"), ValueError("bad json"),
+                     OSError("network down"), KeyError("token")):
+            with self.subTest(error=type(boom).__name__):
+                module = mock.Mock()
+                module.mint.side_effect = boom
+                with mock.patch.object(merge_dev, "_origin",
+                                       return_value=("o", "r")), \
+                     mock.patch.object(merge_dev, "_gh_token_module",
+                                       return_value=module), \
+                     mock.patch.object(merge_dev, "_gh") as fake_gh, \
+                     mock.patch("builtins.print"):
+                    self.assertEqual(merge_dev.main(["merge_dev.py", "12"]), 4)
+                fake_gh.assert_not_called()
+
     def test_credential_failure_stops_without_merging(self):
         module = mock.Mock()
         module.mint.side_effect = RuntimeError("no key on this machine")

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -1,6 +1,7 @@
 """Tests for the seed kit's paved-path merge script's decision logic."""
 
 import importlib.util
+import json
 import pathlib
 import subprocess
 import unittest
@@ -118,6 +119,30 @@ class CredentialTests(unittest.TestCase):
         for name, level in perms.items():
             self.assertIn(level, ("read", "write"))
         self.assertNotIn("administration", perms)
+
+    def test_inspect_token_cannot_merge(self):
+        """A refused PR never has a merge-capable credential in the room."""
+        for level in merge_dev.INSPECT_PERMISSIONS.values():
+            self.assertEqual(level, "read")
+        self.assertEqual(merge_dev.MERGE_PERMISSIONS["contents"], "write")
+        self.assertEqual(merge_dev.MERGE_PERMISSIONS["pull_requests"], "write")
+
+    def test_refused_pr_never_mints_write_permissions(self):
+        minted = []
+
+        def fake_mint(account, repositories, permissions, **kwargs):
+            minted.append(dict(permissions))
+            return "ghs_stub", "later"
+
+        module = mock.Mock(mint=fake_mint)
+        blocked = json.dumps(pr(isDraft=True))
+        with mock.patch.object(merge_dev, "_origin", return_value=("o", "r")), \
+             mock.patch.object(merge_dev, "_gh_token_module", return_value=module), \
+             mock.patch.object(merge_dev, "_gh", return_value=blocked), \
+             mock.patch("builtins.print"):
+            self.assertEqual(merge_dev.main(["merge_dev.py", "12"]), 1)
+        self.assertEqual(len(minted), 1, "a refused PR must mint once, to read")
+        self.assertNotIn("write", minted[0].values())
 
     def test_scoped_to_this_repository_only(self):
         seen = {}


### PR DESCRIPTION
## Why this change

Issue #22, and the interim state Grant 4 shipped into. As of PR #24 the App's org-level Administration is live on `warblersafety` — real capability, granted 2026-08-20 — while Grant 4 sits **dormant** because nothing calls `gh_token.py`, and the PAT is still live with broad reach. So the ceiling is raised, two credentials exist side by side, and the control that answers the ceiling is inert. That is the ordering `decisions/0003` exists to prevent; it is why the grant shipped dormant, and this PR is its named precondition.

Closes #22.

## What changed

**`seed/scripts/merge_dev.py`** mints its own token via `gh_token.py`, scoped to the repository it operates on (derived from the git remote, offline) and to exactly five permissions. On any credential failure it prints `CREDENTIAL FAILURE`, returns 4, and never calls `gh` — no fallback to ambient auth, because a silent fallback is how a broad standing token survives a migration meant to remove it.

**`seed/scripts/gh_token.py`** — elevation is level-sensitive for the *reason* requirement only; every mint naming an elevated permission is still recorded. See "discovered mid-unit" below, and the fix-round comments for how both review lanes moved this.

**`.claude/skills/bootstrap/SKILL.md`** copies `gh_token.py` alongside `merge_dev.py`. Without it every bootstrapped repo gets a merge script that cannot authenticate — blocking, so fixed here rather than deferred to #23.

**`seed/CLAUDE.md.template`** states the credential rule a bootstrapped repo now lives under.

## Two criteria answered explicitly rather than by default

**Criterion 3 — `merge_dev.py`'s CI read.** The premise was partly wrong: the Actions-API workaround is **not in the seed**. It was done in `sofa-scratch`'s copy and never harvested back; the seed still reads `statusCheckRollup`. The real question was whether that field works under an App token on a private repo, since #20 found combined commit status 403s while check-runs succeed, and the field merges both. Tested against private `smansf/sofa-scratch`: it fails with `Resource not accessible by integration (…checkSuite.workflowRun)` **unless `actions: read` is granted**, and works with it. So `statusCheckRollup` stays, no workaround is needed, and the permission set records why. `sofa-scratch`'s own copy can drop its workaround, but that is its repo's business, not this one's.

**Criterion 4 — Actions workflows.** No change, deliberately. `seed/workflows/ci.yml` and `.github/workflows/checks.yml` use `${{ secrets.GITHUB_TOKEN }}`, which is the Actions-native ephemeral token — issued per job, scoped by the workflow's own `permissions:` block, revoked when the job ends. It is not a PAT and never was. Replacing it with `actions/create-github-app-token` would swap an automatically-scoped, job-lifetime credential for one carrying broader App permissions. The criterion said workflows must not *carry a PAT*; they do not.

## Discovered mid-unit, fixed in flight

Testing criterion 3 exposed a defect in `gh_token.py` from PR #24: `actions=read` triggered an elevation record and demanded a reason. Read is not elevation — `actions: read` is what an ordinary CI check needs, and recording it would bury the writes that matter. The audit log is Grant 4's detection control, and a control no one can read is not one. `elevated_permissions()` now triggers on write levels only.

Fixed here rather than filed (#18) because it blocked this unit: without it every merge would demand a stated reason. The doc-review then pushed back on the first version of that fix — it had also stopped *recording* read-level mints, narrowing Grant 4's detection control to save a few lines a day. The shipped form records every mint naming an elevated permission at any level, and demands a reason only for writes.

## Not in scope

- **PAT revocation.** Steve's ceremony, and premature until #23 lands too — filed separately so it cannot happen early.
- **`~/.claude/CLAUDE.md`'s credential rule** still names `GH_TOKEN`. Grant 4 activates only when #22 *and* #23 have merged, so the mirror updates then, not now. Tracked for the digest.
- **`bootstrap/SKILL.md`'s "Expect this to 403"** line still cites the closed #14 and a constraint that no longer exists. That is #23's core scope; rewriting it here would be building the next unit in flight (#18).

## Verification

48 tests pass, including new coverage for remote parsing, least-privilege permissions, repo scoping, and the credential-failure path asserting `gh` is never called.

Live, end to end:

| check | result |
|---|---|
| `merge_dev.py 24` under the App | minted read-only, read the PR, `REFUSED` on five real blockers, exit 1 |
| routine merge audit entries | one `requested`/`granted` pair, all-read permissions, empty reason |
| `SOFA_APP_KEY` missing | `CREDENTIAL FAILURE`, exit 4, `gh` never called |
| `statusCheckRollup` on private repo, no `actions:read` | `Resource not accessible by integration` |
| `statusCheckRollup` on private repo, with `actions:read` | full rollup returned |

## Review

Seam artifact, so both lanes. Adversarial doc-review brief posted before it runs.
