### PR TITLE
Request the commit-statuses permission the rollup query needs

### DIFF
--- a/seed/scripts/merge_dev.py
+++ b/seed/scripts/merge_dev.py
@@ -40,7 +40,8 @@ import sys
 # `evaluate()` has returned no blockers.
 INSPECT_PERMISSIONS = {
     "pull_requests": "read",   # the PR, and its comments
-    "checks": "read",
+    "checks": "read",          # CheckRun nodes in the rollup
+    "statuses": "read",        # StatusContext nodes — see below
     "actions": "read",         # statusCheckRollup resolves workflow runs
     "contents": "read",
     "metadata": "read",
@@ -48,14 +49,15 @@ INSPECT_PERMISSIONS = {
 MERGE_PERMISSIONS = dict(INSPECT_PERMISSIONS,
                          contents="write",       # squash-merge, delete branch
                          pull_requests="write")  # perform the merge
-# NOT included: `statuses`. statusCheckRollup also returns StatusContext
-# nodes — commit statuses, which is what a Vercel preview posts — and
-# those are read under a separate Commit statuses permission the App has
-# not been granted (requesting it 422s the whole mint). Until it is
-# granted, a repo whose CI posts commit statuses may see them missing
-# from the rollup, and a missing check is not evaluated as a blocker.
-# Tracked in sofa-claude Issue #26; REQUIRED_CHECKS still catches an
-# absent required check, which is the case that matters most.
+# `statusCheckRollup` returns two node shapes and each needs its own
+# permission: CheckRun (`checks`) and StatusContext (`statuses`) — the
+# latter is what a deployment preview posts. `evaluate()` reads both, via
+# `name or context` and `conclusion or state`. Omitting `statuses` does
+# not fail loudly: the rollup comes back without those nodes, and a check
+# that never reaches `evaluate()` cannot block, so a failing preview would
+# silently stop being a blocker. Every permission the rollup query needs
+# is therefore listed here, not just the one node type that was tested
+# first (sofa-claude Issue #26).
 
 
 def _gh_token_module():

--- a/tests/test_merge_dev.py
+++ b/tests/test_merge_dev.py
@@ -91,6 +91,29 @@ class EvaluateTests(unittest.TestCase):
         self.assertEqual(len(blockers), 6)
 
 
+class CommitStatusTests(unittest.TestCase):
+    """statusCheckRollup mixes CheckRun and StatusContext nodes."""
+
+    def test_failing_commit_status_blocks_the_merge(self):
+        rollup = GREEN + [{"context": "vercel — preview", "state": "FAILURE"}]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("vercel — preview" in b for b in blockers), blockers)
+
+    def test_pending_commit_status_blocks_the_merge(self):
+        rollup = GREEN + [{"context": "vercel — preview", "state": "PENDING"}]
+        blockers = merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW])
+        self.assertTrue(any("vercel — preview" in b for b in blockers), blockers)
+
+    def test_successful_commit_status_does_not_block(self):
+        rollup = GREEN + [{"context": "vercel — preview", "state": "SUCCESS"}]
+        self.assertEqual(merge_dev.evaluate(pr(statusCheckRollup=rollup), [REVIEW]), [])
+
+    def test_the_permission_that_makes_those_nodes_visible_is_requested(self):
+        """Without it the nodes never arrive, and what never arrives cannot block."""
+        self.assertEqual(merge_dev.INSPECT_PERMISSIONS["statuses"], "read")
+        self.assertEqual(merge_dev.MERGE_PERMISSIONS["statuses"], "read")
+
+
 class RepoSlugTests(unittest.TestCase):
     def test_parses_ssh_and_https_remotes(self):
         for url in ("git@github.com:warblersafety/wilson.git",


### PR DESCRIPTION
## Why this change

Issue #26, found by the adversarial doc-review on PR #25 and confirmed against the API. `merge_dev.py` decides whether a PR may merge by reading `statusCheckRollup`. That field returns **two** node shapes — `CheckRun` and `StatusContext` — gated by two different App permissions. Only `checks` was requested, because check-runs were the only shape I tested when deriving the permission set on PR #25.

The failure mode is silent, which is what makes it worth a PR of its own rather than waiting behind #23. Omitting `statuses` does not error: the rollup comes back without those nodes, `evaluate()` never sees them, and a check that never arrives cannot block. A failing deployment preview would simply stop being a blocker, with no message. `REQUIRED_CHECKS` does not catch it because a preview status is not a required check. `seed/CLAUDE.md.template` anticipates exactly this producer via `{{VERCEL_PREVIEW}}`.

This could not be fixed on PR #25: the App had not been granted Commit statuses, and requesting an ungranted permission `422`s the entire mint — so the code change would have broken the merge path outright rather than improving it. Steve granted it and approved the pending update on both installations (2026-08-20).

Closes #26.

## What changed

`statuses: read` joins `INSPECT_PERMISSIONS` (and so `MERGE_PERMISSIONS`, which derives from it). The comment that pointed at #26 is replaced by one stating the underlying rule: every permission the rollup query needs is listed, not just the node type that happened to be tested first.

No change to `evaluate()` — it already handled both shapes via `name or context` and `conclusion or state`. Nothing was reading commit statuses because nothing was fetching them.

## Verification

61 tests pass. The four new ones test the behaviour rather than the permission constant:

| test | asserts |
|---|---|
| failing `StatusContext` | blocks the merge |
| pending `StatusContext` | blocks the merge |
| successful `StatusContext` | does not block |
| permission present | the nodes can actually arrive |

Live, against the private `smansf/sofa-scratch`:

```
statuses:read mint                      {"metadata":"read","statuses":"read"}
merge_dev.py under the widened set      REFUSED on real blockers, exit 1
statusCheckRollup with statuses         resolves — CheckRun, CheckRun, CheckRun
```

The rollup on that repo contains only `CheckRun` nodes, so this confirms the widened permission set does not break the existing path. It cannot confirm a real `StatusContext` end to end: creating a commit status needs `statuses: write`, which the App deliberately does not have. The unit tests cover that shape directly, and the first Vercel-wired repo will exercise it for real.

## Review

Seam artifact, so both lanes. Adversarial doc-review brief posted before it runs.