### PR TITLE
Rework bootstrap and onboard for the App regime

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -7,6 +7,13 @@ description: Bootstrap a workload repo from the seed kit — elicit a charter wi
 
 Run this *from the workload repo's own directory*, never from sofa-claude.
 
+Every `gh` call in this skill runs under a short-lived App token minted
+by the workload's own copy of the helper — `python3 scripts/gh_token.py
+--account <owner> --repos <name> --perm <name=level> -- gh ...` — never
+ambient session auth. Grant 4's regime has no ambient fallback, and a
+step that "just works" on session credentials today is the step that
+breaks the day the PAT is gone.
+
 1. **Charter first** (`docs/charter.md`, one page, elicited from Steve):
    what is being built and why; who uses it; the **stakes tier**
    (throwaway / standard / production) that sets review depth everywhere;
@@ -58,27 +65,43 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    reports no data and fails, which is defect 2 recurring one step later,
    because the floor and the test run are the same command. Real module
    plus real test satisfies every floor shape.
-4. **Wire the repo**: run `wire_repo.py --repo OWNER/NAME --checkout .`
-   from this skill's directory. It creates `dev` and `staging`, sets `dev`
-   as the default branch, applies the `protect-main` / `protect-staging`
-   rulesets, and then **probes what GitHub actually enforces** — a no-op
-   fast-forward on each protected branch, refused if protection is real.
-   A 201 from the rulesets API is not protection; only the probe is. It
-   takes its credential from the repo's own `scripts/gh_token.py`, so it
-   stops if the seed copy is incomplete rather than wiring a repo whose
-   merge path could never authenticate. Exit 0 means everything that
-   should be protected is; **exit 5 means wired but NOT protected** —
-   normal on a private repo, since free-plan rulesets cover public repos
-   only and org-level rulesets need Enterprise. Exit 5 is never a pass:
-   copy its summary verbatim into the repo's CLAUDE.md **and** the
-   needs-Steve digest, and fill `{{ENFORCEMENT}}` in the seeded CLAUDE.md
-   from it, so the distinction between technical and process-only
-   enforcement outlives this session. Step 6's placeholder grep catches it
-   if you skip that. Exit 4 means nothing
-   was wired; fix the cause, do not proceed.
+4. **Wire the repo**: from the workload repo's root — where this whole
+   skill already runs — invoke
+   `python3 ~/.claude/skills/bootstrap/wire_repo.py --repo OWNER/NAME
+   --checkout .`. The script lives in the skill; the credential comes
+   from the checkout (`scripts/gh_token.py`), so it stops if the seed
+   copy is incomplete rather than wiring a repo whose merge path could
+   never authenticate. It creates `dev` and `staging`, sets `dev` as the
+   default branch, applies the `protect-main` / `protect-staging`
+   rulesets — requiring **one approving human review** on the merge
+   path, because zero approvals requires a PR, not a human — and then
+   **verifies what GitHub actually enforces**, on both paths a change
+   can take: a no-op fast-forward push that must be refused *by rules*
+   (an error is not a refusal), and a read-back of the rules GitHub
+   reports as applying to the branch, which must include that
+   one-approval merge gate. A 201 from the rulesets API is not
+   protection; only the two checks together are. Exit 0 means everything
+   that should be protected is. **Exit 5 means wired but NOT protected**,
+   and its summary says which of two very different things happened:
+   the free-plan limitation (rulesets cover public repos only, org-level
+   rulesets need Enterprise — an accepted outcome: copy the summary
+   verbatim into the repo's CLAUDE.md **and** the central needs-Steve
+   digest, smansf/sofa-claude Issue #2, workload repos carry no digest
+   of their own, and fill `{{ENFORCEMENT}}` in the seeded CLAUDE.md from
+   it so the distinction outlives this session — step 6's placeholder
+   grep catches it if you skip that), or **recorded-but-unenforced**,
+   an anomaly to investigate and never to record as accepted. **Exit 4
+   means wiring or verification failed partway**: its output lists
+   exactly what had been done — and says so when nothing was — but none
+   of it is verified. Fix the cause and re-run; never treat exit 4 as
+   either clean or wired.
    **Disable "automatically delete head branches"**
-   (`gh repo edit --delete-branch-on-merge=false`, then confirm with
-   `gh repo view --json deleteBranchOnMerge`): a promotion PR's head *is*
+   (`python3 scripts/gh_token.py --account OWNER --repos NAME
+   --perm administration=write --reason "bootstrap OWNER/NAME: turn off
+   delete-branch-on-merge" -- gh repo edit OWNER/NAME
+   --delete-branch-on-merge=false`, then confirm under a read mint:
+   `... --perm metadata=read -- gh repo view OWNER/NAME --json
+   deleteBranchOnMerge`): a promotion PR's head *is*
    a long-lived branch, so the setting deletes `staging` the first time
    Steve promotes to `main`, and `merge_dev.py` already deletes unit
    branches itself. The App can do this now — it holds repository
@@ -88,10 +111,11 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    seeded CLAUDE.md carries the check at the moment it bites, holding the
    *first promotion* until the setting is off.
    Create labels `urgent`, `keep`,
-   `standing`; create the standing handoff issue **labeled `standing`**
-   (unlabeled, the repo's own expiry workflow will close it) and fill
-   `{{HANDOFF_ISSUE}}` in CLAUDE.md with its number. Vercel wiring is
-   Steve's step — list it in the needs-Steve digest, don't wait.
+   `standing`, and the standing handoff issue **labeled `standing`**
+   (unlabeled, the repo's own expiry workflow will close it), all under
+   one `--perm issues=write` mint; fill `{{HANDOFF_ISSUE}}` in CLAUDE.md
+   with the issue's number. Vercel wiring is Steve's step — list it in
+   the needs-Steve digest, don't wait.
 5. **Propose the first unit**: one issue, frozen acceptance criteria,
    sized to reach `dev` within a session. Product code, not process — if
    the process pinches during the unit, that's a sofa-claude bleed to
@@ -100,8 +124,9 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    Runs **after the bootstrap PR merges**; if the session ends first
    (production stakes waiting on Steve's review), record step 6 as owed
    in the new repo's handoff issue — the next session runs it before any
-   unit work. Mechanically confirm, via `gh` against the default branch,
-   every item steps 3–4 claimed: default branch is `dev`; `staging`
+   unit work. Mechanically confirm, via `gh` against the default branch
+   (one `--perm contents=read --perm issues=read --perm metadata=read`
+   mint covers this step's reads), every item steps 3–4 claimed: default branch is `dev`; `staging`
    exists; labels `urgent`, `keep`, `standing` exist; `ci.yml`,
    `backlog-expiry.yml`, `pull_request_template.md`, both issue templates
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -58,25 +58,35 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    reports no data and fails, which is defect 2 recurring one step later,
    because the floor and the test run are the same command. Real module
    plus real test satisfies every floor shape.
-4. **Wire the repo**: create `dev` and `staging` from `main`; **set `dev`
-   as the default branch, then verify it stuck** (`gh repo view --json
-   defaultBranchRef` must say `dev` — if it doesn't, stop wiring and put
-   it in the needs-Steve digest, because unit auto-close and the expiry
-   record both silently lie until it's fixed). Unit issues then auto-close
-   when their PR merges to `dev`, and new PRs target `dev` by default.
+4. **Wire the repo**: run `wire_repo.py --repo OWNER/NAME --checkout .`
+   from this skill's directory. It creates `dev` and `staging`, sets `dev`
+   as the default branch, applies the `protect-main` / `protect-staging`
+   rulesets, and then **probes what GitHub actually enforces** — a no-op
+   fast-forward on each protected branch, refused if protection is real.
+   A 201 from the rulesets API is not protection; only the probe is. It
+   takes its credential from the repo's own `scripts/gh_token.py`, so it
+   stops if the seed copy is incomplete rather than wiring a repo whose
+   merge path could never authenticate. Exit 0 means everything that
+   should be protected is; **exit 5 means wired but NOT protected** —
+   normal on a private repo, since free-plan rulesets cover public repos
+   only and org-level rulesets need Enterprise. Exit 5 is never a pass:
+   copy its summary verbatim into the repo's CLAUDE.md **and** the
+   needs-Steve digest, and fill `{{ENFORCEMENT}}` in the seeded CLAUDE.md
+   from it, so the distinction between technical and process-only
+   enforcement outlives this session. Step 6's placeholder grep catches it
+   if you skip that. Exit 4 means nothing
+   was wired; fix the cause, do not proceed.
    **Disable "automatically delete head branches"**
    (`gh repo edit --delete-branch-on-merge=false`, then confirm with
    `gh repo view --json deleteBranchOnMerge`): a promotion PR's head *is*
    a long-lived branch, so the setting deletes `staging` the first time
    Steve promotes to `main`, and `merge_dev.py` already deletes unit
-   branches itself. **Expect this to 403** — repo administration is
-   outside the current token (sofa-claude Issue #14), so the normal
-   outcome is a needs-Steve digest entry with the exact click path
-   (Settings → General, ~15 s), not a repaired setting. Do not write it as
-   a standing bar the repo starts out violating: the seeded CLAUDE.md
-   carries the check at the moment it bites, holding the *first promotion*
-   until the setting is off. Branch protection also exempts a branch, but
-   is unavailable on private repos at this plan — never rely on it.
+   branches itself. The App can do this now — it holds repository
+   administration — so a 403 here is a real failure to investigate, not
+   the expected outcome it once was (sofa-claude Issue #14, closed).
+   Do not write it as a standing bar the repo starts out violating: the
+   seeded CLAUDE.md carries the check at the moment it bites, holding the
+   *first promotion* until the setting is off.
    Create labels `urgent`, `keep`,
    `standing`; create the standing handoff issue **labeled `standing`**
    (unlabeled, the repo's own expiry workflow will close it) and fill
@@ -97,10 +107,14 @@ Run this *from the workload repo's own directory*, never from sofa-claude.
    (`config.yml` with `blank_issues_enabled: false`), `.gitignore`, and
    `scripts/merge_dev.py` (its `REQUIRED_CHECKS` matching ci.yml's job
    names, its executable bit intact) and `scripts/gh_token.py` are all
-   present; **the credential path actually works** — mint a read-only
-   token for this repo and run one `gh` call under it, because the file
-   being present proves nothing about the repo being inside the App's
-   installation. A personal-account installation is scoped to selected
+   present; **the credential path actually works** — mint
+   `merge_dev.MERGE_PERMISSIONS` verbatim and run one `gh` call under it.
+   Not a read-only token, and not a hand-written subset: requesting a
+   permission the installation has not been granted 422s the *whole* mint,
+   so a narrower probe passes while the merge path is dead. The file being
+   present proves nothing about the repo being inside the App's
+   installation, and a green mint of the wrong permissions proves nothing
+   about the merge. A personal-account installation is scoped to selected
    repositories and a new repo is **not** added automatically; adding it
    needs a user-to-server token, so it is Steve's ceremony, not Claude's.
    A mint that fails here means the first unit will reach a green PR and

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -72,44 +72,40 @@ breaks the day the PAT is gone.
    from the checkout (`scripts/gh_token.py`), so it stops if the seed
    copy is incomplete rather than wiring a repo whose merge path could
    never authenticate. It creates `dev` and `staging`, sets `dev` as the
-   default branch, applies the `protect-main` / `protect-staging`
+   default branch, **disables delete-branch-on-merge in the same
+   call** — a promotion PR's head *is* a long-lived branch, so left on,
+   the setting deletes `staging` the first time Steve promotes to
+   `main`, while `merge_dev.py` already deletes unit branches itself —
+   applies the `protect-main` / `protect-staging`
    rulesets — requiring **one approving human review** on the merge
    path, because zero approvals requires a PR, not a human — and then
-   **verifies what GitHub actually enforces**, on both paths a change
-   can take: a no-op fast-forward push that must be refused *by rules*
-   (an error is not a refusal), and a read-back of the rules GitHub
-   reports as applying to the branch, which must include that
-   one-approval merge gate. A 201 from the rulesets API is not
-   protection; only the two checks together are. Exit 0 means everything
+   **verifies what GitHub actually enforces**: an independent read-back
+   of the default branch and delete-branch-on-merge (never the write's
+   echo), and both paths a change can take — a no-op fast-forward push
+   that must be refused *by rules* (an error is not a refusal), and a
+   read-back of the rules GitHub reports as applying to the branch,
+   which must include that one-approval merge gate. A 201 from the
+   rulesets API is not protection; only the two checks together are. Exit 0 means everything
    that should be protected is. **Exit 5 means wired but NOT protected**,
    and its summary says which of two very different things happened:
    the free-plan limitation (rulesets cover public repos only, org-level
    rulesets need Enterprise — an accepted outcome: copy the summary
    verbatim into the repo's CLAUDE.md **and** the central needs-Steve
-   digest, smansf/sofa-claude Issue #2, workload repos carry no digest
-   of their own, and fill `{{ENFORCEMENT}}` in the seeded CLAUDE.md from
-   it so the distinction outlives this session — step 6's placeholder
+   digest, smansf/sofa-claude Issue #2 — workload repos carry no digest
+   of their own, so this is the one write that leaves the workload's
+   scope: `python3 scripts/gh_token.py --account smansf --repos
+   sofa-claude --perm issues=write --reason "needs-Steve digest" -- gh
+   issue edit 2 --repo smansf/sofa-claude --body-file ...`; if that mint
+   fails, the App's smansf installation does not cover sofa-claude —
+   tell Steve in the recap instead of writing nothing silently — and
+   fill `{{ENFORCEMENT}}` in the seeded CLAUDE.md from the same summary
+   so the distinction outlives this session — step 6's placeholder
    grep catches it if you skip that), or **recorded-but-unenforced**,
    an anomaly to investigate and never to record as accepted. **Exit 4
    means wiring or verification failed partway**: its output lists
    exactly what had been done — and says so when nothing was — but none
    of it is verified. Fix the cause and re-run; never treat exit 4 as
    either clean or wired.
-   **Disable "automatically delete head branches"**
-   (`python3 scripts/gh_token.py --account OWNER --repos NAME
-   --perm administration=write --reason "bootstrap OWNER/NAME: turn off
-   delete-branch-on-merge" -- gh repo edit OWNER/NAME
-   --delete-branch-on-merge=false`, then confirm under a read mint:
-   `... --perm metadata=read -- gh repo view OWNER/NAME --json
-   deleteBranchOnMerge`): a promotion PR's head *is*
-   a long-lived branch, so the setting deletes `staging` the first time
-   Steve promotes to `main`, and `merge_dev.py` already deletes unit
-   branches itself. The App can do this now — it holds repository
-   administration — so a 403 here is a real failure to investigate, not
-   the expected outcome it once was (sofa-claude Issue #14, closed).
-   Do not write it as a standing bar the repo starts out violating: the
-   seeded CLAUDE.md carries the check at the moment it bites, holding the
-   *first promotion* until the setting is off.
    Create labels `urgent`, `keep`,
    `standing`, and the standing handoff issue **labeled `standing`**
    (unlabeled, the repo's own expiry workflow will close it), all under
@@ -155,16 +151,19 @@ breaks the day the PAT is gone.
    forever. An unfilled placeholder is the seed silently ceasing to be
    authoritative, which is the defect class this step exists for. The
    `test` job ran a real command, and the repo tracks at least one test
-   file and the module it covers. `deleteBranchOnMerge` is false, or the
-   needs-Steve digest carries it with the click path;
+   file and the module it covers. `deleteBranchOnMerge` is false —
+   wire_repo set and read it back, so a true here means the wiring was
+   changed since;
    the standing handoff issue exists, carries `standing`, and CLAUDE.md
    names its number. A failed check that one `gh` command repairs is
    re-run once, re-verified, and noted in the
    bootstrap PR — repaired loudly, never silently. What still fails gets
    filed in the new repo, labeled by the seeded triage doctrine —
    `urgent` when it invalidates the first unit's premise, else `keep`;
-   a wrong default branch additionally stays under step 4's
-   stop-and-digest rule. Steve-owed items (Vercel wiring, ruleset
+   a wrong default branch or a true `deleteBranchOnMerge` means
+   something wire_repo verified has been undone — re-run it and
+   investigate before any unit work, never hand-patch the one item.
+   Steve-owed items (Vercel wiring, ruleset
    creation) go in the needs-Steve digest with the exact steps.
    Bootstrap ends only when every check is green or every gap is filed.
 

--- a/.claude/skills/bootstrap/wire_repo.py
+++ b/.claude/skills/bootstrap/wire_repo.py
@@ -25,6 +25,10 @@ Protection is verified on both paths a change can take:
   harmless. It is still evidence rather than an echo of the payload:
   rules GitHub does not enforce drop out of the applying-rules listing.
 
+The default branch and delete-branch-on-merge (wired off in the same
+PATCH — a promotion PR's head is a long-lived branch) are verified by an
+independent read-back, not the PATCH response's echo.
+
 Free-plan repositories only get rulesets when they are **public**. A
 private repo is therefore wired but unprotected, and its human-only merge
 rule is carried by process alone. That is allowed. What is not allowed is
@@ -62,8 +66,17 @@ API = "https://api.github.com"
 # a ruleset refuses a ref write with 422 "Repository rule violations
 # found"; a free-plan private repo answers rule reads with 403 "Upgrade to
 # GitHub Pro or make this repository public to enable this feature."
-RULE_REFUSALS = ("rule violations", "protected branch")
+# Only the ruleset shape is listed: this script creates rulesets, never
+# classic branch protection, and classic protection's refusal shape is
+# unverified — an unlisted refusal is inconclusive and exits 4, loudly,
+# rather than being guessed at.
+RULE_REFUSALS = ("rule violations",)
 PLAN_LIMITS = ("upgrade to github pro", "make this repository public")
+
+
+def plan_limited(detail):
+    """GitHub's plan limitation, positively identified from its message."""
+    return any(s in str(detail).lower() for s in PLAN_LIMITS)
 
 
 class WiringError(RuntimeError):
@@ -174,7 +187,7 @@ def merge_gate(token, owner, repo, branch):
     """
     status, rules = call(token, "GET",
                          f"/repos/{owner}/{repo}/rules/branches/{branch}")
-    if status == 403 and any(s in str(rules).lower() for s in PLAN_LIMITS):
+    if status == 403 and plan_limited(rules):
         return False, ("rules unavailable on this plan for this repo "
                        f"({status}: {rules})")
     if status >= 400:
@@ -197,17 +210,23 @@ def wire(owner, repo, checkout, default="dev", branches=("dev", "staging"),
          protect=("main", "staging")):
     gh_token = load_gh_token(checkout)
     report = {"repo": f"{owner}/{repo}", "default_branch": None,
+              "delete_branch_on_merge": None,
               "branches": {}, "protected": {}, "unprotected": []}
     try:
-        token, _ = gh_token.mint(owner, [repo], {"contents": "write",
-                                                 "metadata": "read"})
-        status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/main")
+        # This token never holds `administration`; verification reuses it
+        # below, so the probes demonstrate what an unprivileged writer can
+        # do. Installation tokens outlive this run by ~an hour.
+        probe_token, _ = gh_token.mint(owner, [repo], {"contents": "write",
+                                                       "metadata": "read"})
+        status, ref = call(probe_token, "GET",
+                           f"/repos/{owner}/{repo}/git/ref/heads/main")
         if status >= 400:
             raise WiringError(f"Cannot read refs/heads/main ({status}: {ref}). "
                               f"Was the repo initialised?")
         base = ref["object"]["sha"]
         for branch in branches:
-            status, detail = call(token, "POST", f"/repos/{owner}/{repo}/git/refs",
+            status, detail = call(probe_token, "POST",
+                                  f"/repos/{owner}/{repo}/git/refs",
                                   {"ref": f"refs/heads/{branch}", "sha": base})
             if status < 400:
                 report["branches"][branch] = "created"
@@ -221,26 +240,67 @@ def wire(owner, repo, checkout, default="dev", branches=("dev", "staging"),
                     f"later probes as unreadable and risks being misread as "
                     f"a plan limitation instead of a missing branch.")
 
-        token, _ = gh_token.mint(
+        admin_token, _ = gh_token.mint(
             owner, [repo], {"administration": "write", "metadata": "read"},
-            reason=f"bootstrap {owner}/{repo}: default branch and branch protection")
-        status, body = call(token, "PATCH", f"/repos/{owner}/{repo}",
-                            {"default_branch": default})
+            reason=f"bootstrap {owner}/{repo}: default branch, merge "
+                   f"settings, and branch protection")
+        # delete_branch_on_merge rides the same PATCH: a promotion PR's
+        # head is a long-lived branch, so left on, the setting deletes
+        # `staging` at the first promotion to `main`.
+        status, body = call(admin_token, "PATCH", f"/repos/{owner}/{repo}",
+                            {"default_branch": default,
+                             "delete_branch_on_merge": False})
         if status >= 400:
-            raise WiringError(f"Could not set the default branch ({status}: {body}).")
+            raise WiringError(f"Could not set the default branch and merge "
+                              f"settings ({status}: {body}).")
+        if body["default_branch"] != default:
+            raise WiringError(
+                f"GitHub accepted the change but reports the default branch "
+                f"as {body['default_branch']!r}, not {default!r} — what it "
+                f"accepted is not what it holds.")
         report["default_branch"] = body["default_branch"]
         for branch in protect:
-            status, body = call(token, "POST", f"/repos/{owner}/{repo}/rulesets",
-                                ruleset_payload(branch))
+            status, detail = call(admin_token, "POST",
+                                  f"/repos/{owner}/{repo}/rulesets",
+                                  ruleset_payload(branch))
             report["protected"][branch] = {"ruleset_api": status}
+            if status < 400:
+                continue
+            if status == 403 and plan_limited(detail):
+                continue  # positively identified; verification confirms below
+            if status == 422 and "already" in str(detail).lower():
+                continue  # a re-run: the ruleset survives from a prior attempt
+            raise WiringError(
+                f"Creating ruleset protect-{branch} failed ({status}: "
+                f"{detail}). Neither the recognised plan limitation nor a "
+                f"re-run duplicate: a rate limit or server error here must "
+                f"fail the wiring, never pass as an accepted plan limitation.")
 
         # Verify what GitHub enforces, not what it accepted — both paths.
-        token, _ = gh_token.mint(owner, [repo], {"contents": "write",
-                                                 "metadata": "read"})
+        # Reuses probe_token: minted before the admin work and never
+        # holding `administration`, so the probes show what an
+        # unprivileged writer can do.
+        status, repo_state = call(probe_token, "GET", f"/repos/{owner}/{repo}")
+        if status >= 400:
+            raise WiringError(f"Cannot read the repo back for verification "
+                              f"({status}: {repo_state}).")
+        # Merge-settings fields are withheld from metadata-only callers;
+        # this token holds contents, which GitHub documents as sufficient.
+        if repo_state.get("default_branch") != default:
+            raise WiringError(
+                f"Read-back says the default branch is "
+                f"{repo_state.get('default_branch')!r}, not {default!r}.")
+        if repo_state.get("delete_branch_on_merge") is not False:
+            raise WiringError(
+                f"delete_branch_on_merge reads back as "
+                f"{repo_state.get('delete_branch_on_merge')!r}, not False — "
+                f"either the setting did not stick or this token cannot see "
+                f"it. Left on, the first promotion deletes staging.")
+        report["delete_branch_on_merge"] = False
         for branch in protect:
             state = report["protected"][branch]
-            pushed, push_detail = push_refused(token, owner, repo, branch)
-            merged, merge_detail = merge_gate(token, owner, repo, branch)
+            pushed, push_detail = push_refused(probe_token, owner, repo, branch)
+            merged, merge_detail = merge_gate(probe_token, owner, repo, branch)
             state["push"] = push_detail
             state["merge"] = merge_detail
             if pushed is None or merged is None:
@@ -249,6 +309,9 @@ def wire(owner, repo, checkout, default="dev", branches=("dev", "staging"),
                     f"(push: {push_detail}; merge: {merge_detail}). Neither "
                     f"ENFORCED nor an accepted limitation can be claimed "
                     f"from an error — fix the cause and re-run.")
+            # Plan-ness comes from GitHub's own message, carried in the
+            # merge detail — never from the POST status alone.
+            state["plan_limited"] = plan_limited(merge_detail)
             state["enforced"] = pushed and merged
             if not state["enforced"]:
                 report["unprotected"].append(branch)
@@ -266,28 +329,33 @@ def summarise(report):
     branches = ", ".join(f"{name} ({state})" for name, state
                          in sorted(report["branches"].items()))
     lines = [f"Wired {report['repo']}: default branch "
-             f"{report['default_branch']!r}, branches {branches}."]
+             f"{report['default_branch']!r} (read back), delete-branch-"
+             f"on-merge {report.get('delete_branch_on_merge')}, "
+             f"branches {branches}."]
     for branch, state in sorted(report["protected"].items()):
         verdict = "ENFORCED" if state.get("enforced") else "NOT ENFORCED"
         lines.append(f"  {branch}: {verdict} (rulesets API returned "
                      f"{state['ruleset_api']})")
         lines.append(f"    push:  {state.get('push')}")
         lines.append(f"    merge: {state.get('merge')}")
-    plan_limited = [b for b in report["unprotected"]
-                    if report["protected"][b]["ruleset_api"] == 403]
-    anomalies = [b for b in report["unprotected"] if b not in plan_limited]
+    # Keyed on GitHub's own plan-limit message as verification saw it —
+    # a bare 403 status is a proxy that rate limits and permission gaps
+    # also produce, and those must never read as an accepted outcome.
+    limited = [b for b in report["unprotected"]
+               if report["protected"][b].get("plan_limited")]
+    anomalies = [b for b in report["unprotected"] if b not in limited]
     if anomalies:
         lines.append("")
         lines.append("RECORDED BUT NOT ENFORCED on: " + ", ".join(anomalies) + ".")
-        lines.append("The rulesets API accepted these rules yet GitHub does "
-                     "not enforce them. This is NOT the free-plan limitation "
-                     "— that refuses the API call outright — so investigate "
-                     "before recording anything; do not write it off as an "
-                     "accepted plan limitation.")
-    if plan_limited:
+        lines.append("GitHub does not enforce these rules, and verification "
+                     "never saw the plan-limit message that is the one "
+                     "acceptable reason for that (the rulesets API status "
+                     "is printed above) — investigate before recording "
+                     "anything; do not write it off as a plan limitation.")
+    if limited:
         lines.append("")
         lines.append("PROCESS-ONLY ENFORCEMENT on: "
-                     + ", ".join(plan_limited) + ".")
+                     + ", ".join(limited) + ".")
         lines.append("Rulesets are unavailable here — on the free plan they "
                      "cover public repositories only, and org-level rulesets "
                      "need Enterprise. Nothing in GitHub will stop a direct "

--- a/.claude/skills/bootstrap/wire_repo.py
+++ b/.claude/skills/bootstrap/wire_repo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Wire a freshly bootstrapped repo, and prove the wiring by behaviour.
+"""Wire a freshly bootstrapped repo, and prove the wiring by verification.
 
 Bootstrap used to hand Steve a manual step here, because the old PAT could
 not administer a repo. The App can, so this does it — and then checks what
@@ -7,28 +7,45 @@ GitHub actually enforces rather than trusting the success codes it just
 received. A 201 from the rulesets API means a ruleset was recorded; it
 does not mean a branch is protected.
 
-The protection probe is a no-op fast-forward: point a branch's ref at the
-sha it already has. On a protected branch GitHub refuses it; on an
-unprotected one it succeeds and changes nothing. Either way it creates no
-commit, no file, and no junk to clean up — which matters because the
-"unprotected" answer is a normal outcome here, not an error.
+Protection is verified on both paths a change can take:
+
+* The push path, by behaviour: a no-op fast-forward — point the branch's
+  ref at the sha it already holds. Refused *by rules* means protected; a
+  plain acceptance means not, and nothing changes either way. An error is
+  not a refusal: a 500, a rate limit, an expired token all mean "could
+  not verify", never "protected".
+
+* The merge path, by reading back the rules GitHub reports as APPLYING
+  to the branch, which must include a pull_request rule requiring at
+  least one approving review. Zero required approvals requires a PR, not
+  a human: a token holding `contents` + `pull_requests` write can open a
+  PR and merge it unreviewed (demonstrated on a throwaway repo — PR #32,
+  finding 1). This is a read-back, not a behavioural probe, because the
+  behavioural test of the merge path is an actual merge, which is not
+  harmless. It is still evidence rather than an echo of the payload:
+  rules GitHub does not enforce drop out of the applying-rules listing.
 
 Free-plan repositories only get rulesets when they are **public**. A
 private repo is therefore wired but unprotected, and its human-only merge
 rule is carried by process alone. That is allowed. What is not allowed is
 it being quiet: this exits 5 in that case, prints the fact, and hands the
-caller a summary to put in the repo's CLAUDE.md and the needs-Steve
-digest.
+caller a summary to put in the repo's CLAUDE.md and the central
+needs-Steve digest (sofa-claude Issue #2).
 
 Exit codes:
-    0  wired, and every branch that should be protected is
+    0  wired, and every branch that should be protected is — both paths
     2  usage error
-    4  credential failure -- nothing was changed
+    4  wiring or verification failed partway. The repo may be partly
+       wired: the output lists exactly what had been done, and says so
+       when nothing had. Fix the cause and re-run.
     5  wired, but at least one branch is NOT protected (loud, not fatal)
 
 Usage:
     wire_repo.py --repo OWNER/NAME --checkout PATH [--default dev]
                  [--branches dev,staging] [--protect main,staging]
+
+Run from the workload repo's root with `--checkout .` — the script lives
+in the skill directory, the credential comes from the checkout.
 """
 
 import argparse
@@ -41,9 +58,17 @@ import urllib.request
 
 API = "https://api.github.com"
 
+# Refusal and plan-limit shapes, verified against the live API 2026-08-20:
+# a ruleset refuses a ref write with 422 "Repository rule violations
+# found"; a free-plan private repo answers rule reads with 403 "Upgrade to
+# GitHub Pro or make this repository public to enable this feature."
+RULE_REFUSALS = ("rule violations", "protected branch")
+PLAN_LIMITS = ("upgrade to github pro", "make this repository public")
+
 
 class WiringError(RuntimeError):
-    """Actionable; never carries a credential."""
+    """Actionable; never carries a credential. May carry a partial
+    `report` attribute listing what had been done before the failure."""
 
 
 def load_gh_token(checkout):
@@ -57,9 +82,10 @@ def load_gh_token(checkout):
     path = pathlib.Path(checkout).expanduser().resolve() / "scripts" / "gh_token.py"
     if not path.exists():
         raise WiringError(
-            f"{path} is missing — the seed copy is incomplete. The merge path "
-            f"in this repo would have no way to authenticate. Fix the copy "
-            f"before wiring.")
+            f"{path} is missing. Either --checkout does not point at the "
+            f"workload repo's root (run from that root with --checkout .), "
+            f"or the seed copy is incomplete. The merge path in this repo "
+            f"would have no way to authenticate; fix that before wiring.")
     spec = importlib.util.spec_from_file_location("gh_token", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -94,12 +120,18 @@ def ruleset_payload(branch):
         "name": f"protect-{branch}",
         "target": "branch",
         "enforcement": "active",
+        # Explicitly nobody: omitting the list means the same today, but
+        # the gate's whole value is that no actor bypasses it, so say so.
+        "bypass_actors": [],
         "conditions": {"ref_name": {"include": [f"refs/heads/{branch}"],
                                     "exclude": []}},
         "rules": [{"type": "deletion"},
                   {"type": "non_fast_forward"},
                   {"type": "pull_request",
-                   "parameters": {"required_approving_review_count": 0,
+                   # 1, not 0: zero approvals requires a PR, not a human —
+                   # a contents+pull_requests token could merge its own PR
+                   # unreviewed (PR #32, finding 1).
+                   "parameters": {"required_approving_review_count": 1,
                                   "dismiss_stale_reviews_on_push": False,
                                   "require_code_owner_review": False,
                                   "require_last_push_approval": False,
@@ -107,88 +139,163 @@ def ruleset_payload(branch):
     }
 
 
-def is_protected(token, owner, repo, branch):
-    """Probe by behaviour. Returns (protected: bool, detail: str).
+def push_refused(token, owner, repo, branch):
+    """Probe the push path by behaviour. Returns (verdict, detail).
 
-    A no-op fast-forward: set the ref to the sha it already holds. Refused
-    means protected; allowed means not, and nothing changed either way.
+    verdict: True = refused by rules, False = write accepted, None =
+    could not verify. The probe is a no-op fast-forward — set the ref to
+    the sha it already holds — so nothing changes whichever answer comes
+    back. Only a recognised rules refusal counts as protection; every
+    other failure is inconclusive, never a refusal.
     """
     status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
     if status >= 400:
-        return False, f"branch {branch} not readable ({status}: {ref})"
+        return None, f"branch {branch} not readable ({status}: {ref})"
     sha = ref["object"]["sha"]
     status, detail = call(token, "PATCH",
                           f"/repos/{owner}/{repo}/git/refs/heads/{branch}",
                           {"sha": sha, "force": False})
+    if status < 400:
+        return False, "a direct write to this branch was ACCEPTED"
+    if status == 422 and any(s in str(detail).lower() for s in RULE_REFUSALS):
+        return True, f"refused by rules ({status}: {detail})"
+    return None, (f"probe inconclusive ({status}: {detail}) — an error is "
+                  f"not a refusal and must never be read as protection")
+
+
+def merge_gate(token, owner, repo, branch):
+    """Read back the merge-path rules GitHub reports as applying.
+    Returns (verdict, detail).
+
+    verdict: True = a pull_request rule applies and requires at least one
+    approving review, False = it does not (including the free-plan case,
+    where GitHub answers rule reads with its recognisable upgrade
+    message), None = could not read.
+    """
+    status, rules = call(token, "GET",
+                         f"/repos/{owner}/{repo}/rules/branches/{branch}")
+    if status == 403 and any(s in str(rules).lower() for s in PLAN_LIMITS):
+        return False, ("rules unavailable on this plan for this repo "
+                       f"({status}: {rules})")
     if status >= 400:
-        return True, f"refused ({status})"
-    return False, "a direct write to this branch was ACCEPTED"
+        return None, f"applying rules not readable ({status}: {rules})"
+    pull_rules = [r for r in rules if r.get("type") == "pull_request"]
+    if not pull_rules:
+        return False, "no pull_request rule applies to this branch"
+    required = max(((r.get("parameters") or {})
+                    .get("required_approving_review_count") or 0)
+                   for r in pull_rules)
+    if required >= 1:
+        return True, (f"pull_request rule applies, {required} approving "
+                      f"review(s) required")
+    return False, ("a pull_request rule applies but requires 0 approving "
+                   "reviews — that requires a PR, not a human; a "
+                   "contents+pull_requests token could merge its own PR")
 
 
 def wire(owner, repo, checkout, default="dev", branches=("dev", "staging"),
          protect=("main", "staging")):
     gh_token = load_gh_token(checkout)
-    account, name = owner, repo
     report = {"repo": f"{owner}/{repo}", "default_branch": None,
               "branches": {}, "protected": {}, "unprotected": []}
+    try:
+        token, _ = gh_token.mint(owner, [repo], {"contents": "write",
+                                                 "metadata": "read"})
+        status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/main")
+        if status >= 400:
+            raise WiringError(f"Cannot read refs/heads/main ({status}: {ref}). "
+                              f"Was the repo initialised?")
+        base = ref["object"]["sha"]
+        for branch in branches:
+            status, detail = call(token, "POST", f"/repos/{owner}/{repo}/git/refs",
+                                  {"ref": f"refs/heads/{branch}", "sha": base})
+            if status < 400:
+                report["branches"][branch] = "created"
+            elif status == 422 and "already exists" in str(detail).lower():
+                report["branches"][branch] = "already existed"
+            else:
+                report["branches"][branch] = f"creation FAILED ({status}: {detail})"
+                raise WiringError(
+                    f"Creating branch {branch!r} failed ({status}: {detail}). "
+                    f"Stopping here: carrying on would leave a branch that "
+                    f"later probes as unreadable and risks being misread as "
+                    f"a plan limitation instead of a missing branch.")
 
-    token, _ = gh_token.mint(account, [name], {"contents": "write",
-                                               "metadata": "read"})
-    status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/main")
-    if status >= 400:
-        raise WiringError(f"Cannot read refs/heads/main ({status}: {ref}). "
-                          f"Was the repo initialised?")
-    base = ref["object"]["sha"]
-    for branch in branches:
-        status, detail = call(token, "POST", f"/repos/{owner}/{repo}/git/refs",
-                              {"ref": f"refs/heads/{branch}", "sha": base})
-        report["branches"][branch] = ("created" if status < 400
-                                      else f"exists or refused ({status})")
+        token, _ = gh_token.mint(
+            owner, [repo], {"administration": "write", "metadata": "read"},
+            reason=f"bootstrap {owner}/{repo}: default branch and branch protection")
+        status, body = call(token, "PATCH", f"/repos/{owner}/{repo}",
+                            {"default_branch": default})
+        if status >= 400:
+            raise WiringError(f"Could not set the default branch ({status}: {body}).")
+        report["default_branch"] = body["default_branch"]
+        for branch in protect:
+            status, body = call(token, "POST", f"/repos/{owner}/{repo}/rulesets",
+                                ruleset_payload(branch))
+            report["protected"][branch] = {"ruleset_api": status}
 
-    token, _ = gh_token.mint(
-        account, [name], {"administration": "write", "metadata": "read"},
-        reason=f"bootstrap {owner}/{repo}: default branch and branch protection")
-    status, body = call(token, "PATCH", f"/repos/{owner}/{repo}",
-                        {"default_branch": default})
-    if status >= 400:
-        raise WiringError(f"Could not set the default branch ({status}: {body}).")
-    report["default_branch"] = body["default_branch"]
-    for branch in protect:
-        status, body = call(token, "POST", f"/repos/{owner}/{repo}/rulesets",
-                            ruleset_payload(branch))
-        report["protected"][branch] = {"ruleset_api": status}
-
-    # Verify what GitHub enforces, not what it accepted.
-    token, _ = gh_token.mint(account, [name], {"contents": "write",
-                                               "metadata": "read"})
-    for branch in protect:
-        protected, detail = is_protected(token, owner, repo, branch)
-        report["protected"][branch]["enforced"] = protected
-        report["protected"][branch]["probe"] = detail
-        if not protected:
-            report["unprotected"].append(branch)
+        # Verify what GitHub enforces, not what it accepted — both paths.
+        token, _ = gh_token.mint(owner, [repo], {"contents": "write",
+                                                 "metadata": "read"})
+        for branch in protect:
+            state = report["protected"][branch]
+            pushed, push_detail = push_refused(token, owner, repo, branch)
+            merged, merge_detail = merge_gate(token, owner, repo, branch)
+            state["push"] = push_detail
+            state["merge"] = merge_detail
+            if pushed is None or merged is None:
+                raise WiringError(
+                    f"Protection on {branch!r} could not be verified "
+                    f"(push: {push_detail}; merge: {merge_detail}). Neither "
+                    f"ENFORCED nor an accepted limitation can be claimed "
+                    f"from an error — fix the cause and re-run.")
+            state["enforced"] = pushed and merged
+            if not state["enforced"]:
+                report["unprotected"].append(branch)
+    except WiringError as err:
+        err.report = report
+        raise
+    except Exception as err:
+        wrapped = WiringError(f"{type(err).__name__}: {err}")
+        wrapped.report = report
+        raise wrapped from err
     return report
 
 
 def summarise(report):
+    branches = ", ".join(f"{name} ({state})" for name, state
+                         in sorted(report["branches"].items()))
     lines = [f"Wired {report['repo']}: default branch "
-             f"{report['default_branch']!r}, branches "
-             f"{', '.join(sorted(report['branches']))}."]
+             f"{report['default_branch']!r}, branches {branches}."]
     for branch, state in sorted(report["protected"].items()):
         verdict = "ENFORCED" if state.get("enforced") else "NOT ENFORCED"
-        lines.append(f"  {branch}: {verdict} — probe {state.get('probe')} "
-                     f"(rulesets API returned {state['ruleset_api']})")
-    if report["unprotected"]:
+        lines.append(f"  {branch}: {verdict} (rulesets API returned "
+                     f"{state['ruleset_api']})")
+        lines.append(f"    push:  {state.get('push')}")
+        lines.append(f"    merge: {state.get('merge')}")
+    plan_limited = [b for b in report["unprotected"]
+                    if report["protected"][b]["ruleset_api"] == 403]
+    anomalies = [b for b in report["unprotected"] if b not in plan_limited]
+    if anomalies:
+        lines.append("")
+        lines.append("RECORDED BUT NOT ENFORCED on: " + ", ".join(anomalies) + ".")
+        lines.append("The rulesets API accepted these rules yet GitHub does "
+                     "not enforce them. This is NOT the free-plan limitation "
+                     "— that refuses the API call outright — so investigate "
+                     "before recording anything; do not write it off as an "
+                     "accepted plan limitation.")
+    if plan_limited:
         lines.append("")
         lines.append("PROCESS-ONLY ENFORCEMENT on: "
-                     + ", ".join(report["unprotected"]) + ".")
+                     + ", ".join(plan_limited) + ".")
         lines.append("Rulesets are unavailable here — on the free plan they "
                      "cover public repositories only, and org-level rulesets "
                      "need Enterprise. Nothing in GitHub will stop a direct "
-                     "push to those branches; the human-only merge rule is "
-                     "carried by process alone.")
-        lines.append("Record this in the repo's CLAUDE.md and the needs-Steve "
-                     "digest. It is an accepted outcome, not a silent one.")
+                     "push or an unreviewed merge to those branches; the "
+                     "human-only merge rule is carried by process alone.")
+        lines.append("Record this in the repo's CLAUDE.md and the central "
+                     "needs-Steve digest (sofa-claude Issue #2). It is an "
+                     "accepted outcome, not a silent one.")
     return "\n".join(lines)
 
 
@@ -211,8 +318,19 @@ def main(argv=None):
         report = wire(owner, name, args.checkout, args.default,
                       split(args.branches), split(args.protect))
     except Exception as err:
-        print(f"WIRING FAILURE — the repo may be partly wired.\n{err}",
+        print("WIRING FAILURE — the repo may be partly wired. Fix the cause "
+              "and re-run; treat exit 4 as neither clean nor wired.",
               file=sys.stderr)
+        print(str(err), file=sys.stderr)
+        partial = getattr(err, "report", None)
+        done = partial and (partial["default_branch"] is not None
+                            or partial["branches"] or partial["protected"])
+        if done:
+            print("Done before the failure (none of it verified):",
+                  file=sys.stderr)
+            print(json.dumps(partial, indent=2), file=sys.stderr)
+        else:
+            print("Nothing had been changed yet.", file=sys.stderr)
         return 4
     print(json.dumps(report, indent=2) if args.json else summarise(report))
     return 5 if report["unprotected"] else 0

--- a/.claude/skills/bootstrap/wire_repo.py
+++ b/.claude/skills/bootstrap/wire_repo.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Wire a freshly bootstrapped repo, and prove the wiring by behaviour.
+
+Bootstrap used to hand Steve a manual step here, because the old PAT could
+not administer a repo. The App can, so this does it — and then checks what
+GitHub actually enforces rather than trusting the success codes it just
+received. A 201 from the rulesets API means a ruleset was recorded; it
+does not mean a branch is protected.
+
+The protection probe is a no-op fast-forward: point a branch's ref at the
+sha it already has. On a protected branch GitHub refuses it; on an
+unprotected one it succeeds and changes nothing. Either way it creates no
+commit, no file, and no junk to clean up — which matters because the
+"unprotected" answer is a normal outcome here, not an error.
+
+Free-plan repositories only get rulesets when they are **public**. A
+private repo is therefore wired but unprotected, and its human-only merge
+rule is carried by process alone. That is allowed. What is not allowed is
+it being quiet: this exits 5 in that case, prints the fact, and hands the
+caller a summary to put in the repo's CLAUDE.md and the needs-Steve
+digest.
+
+Exit codes:
+    0  wired, and every branch that should be protected is
+    2  usage error
+    4  credential failure -- nothing was changed
+    5  wired, but at least one branch is NOT protected (loud, not fatal)
+
+Usage:
+    wire_repo.py --repo OWNER/NAME --checkout PATH [--default dev]
+                 [--branches dev,staging] [--protect main,staging]
+"""
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+
+
+class WiringError(RuntimeError):
+    """Actionable; never carries a credential."""
+
+
+def load_gh_token(checkout):
+    """Import the credential path from the repo being wired.
+
+    Deliberately sourced from the target checkout, not from this skill:
+    if bootstrap failed to copy `scripts/gh_token.py`, wiring stops here
+    rather than succeeding and leaving a repo whose merge path cannot
+    authenticate.
+    """
+    path = pathlib.Path(checkout).expanduser().resolve() / "scripts" / "gh_token.py"
+    if not path.exists():
+        raise WiringError(
+            f"{path} is missing — the seed copy is incomplete. The merge path "
+            f"in this repo would have no way to authenticate. Fix the copy "
+            f"before wiring.")
+    spec = importlib.util.spec_from_file_location("gh_token", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def call(token, method, path, payload=None):
+    request = urllib.request.Request(
+        API + path, method=method,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        headers={"Authorization": "Bearer " + token,
+                 "Accept": "application/vnd.github+json",
+                 "X-GitHub-Api-Version": "2022-11-28",
+                 "User-Agent": "sofa-claude-bootstrap"})
+    try:
+        with urllib.request.urlopen(request) as response:
+            body = response.read()
+            return response.status, (json.loads(body) if body else None)
+    except urllib.error.HTTPError as err:
+        detail = ""
+        try:
+            detail = json.loads(err.read()).get("message", "")
+        except Exception:
+            pass
+        return err.code, detail
+    except urllib.error.URLError as err:
+        raise WiringError(f"Cannot reach GitHub for {method} {path}: {err.reason}")
+
+
+def ruleset_payload(branch):
+    return {
+        "name": f"protect-{branch}",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": [f"refs/heads/{branch}"],
+                                    "exclude": []}},
+        "rules": [{"type": "deletion"},
+                  {"type": "non_fast_forward"},
+                  {"type": "pull_request",
+                   "parameters": {"required_approving_review_count": 0,
+                                  "dismiss_stale_reviews_on_push": False,
+                                  "require_code_owner_review": False,
+                                  "require_last_push_approval": False,
+                                  "required_review_thread_resolution": False}}],
+    }
+
+
+def is_protected(token, owner, repo, branch):
+    """Probe by behaviour. Returns (protected: bool, detail: str).
+
+    A no-op fast-forward: set the ref to the sha it already holds. Refused
+    means protected; allowed means not, and nothing changed either way.
+    """
+    status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/{branch}")
+    if status >= 400:
+        return False, f"branch {branch} not readable ({status}: {ref})"
+    sha = ref["object"]["sha"]
+    status, detail = call(token, "PATCH",
+                          f"/repos/{owner}/{repo}/git/refs/heads/{branch}",
+                          {"sha": sha, "force": False})
+    if status >= 400:
+        return True, f"refused ({status})"
+    return False, "a direct write to this branch was ACCEPTED"
+
+
+def wire(owner, repo, checkout, default="dev", branches=("dev", "staging"),
+         protect=("main", "staging")):
+    gh_token = load_gh_token(checkout)
+    account, name = owner, repo
+    report = {"repo": f"{owner}/{repo}", "default_branch": None,
+              "branches": {}, "protected": {}, "unprotected": []}
+
+    token, _ = gh_token.mint(account, [name], {"contents": "write",
+                                               "metadata": "read"})
+    status, ref = call(token, "GET", f"/repos/{owner}/{repo}/git/ref/heads/main")
+    if status >= 400:
+        raise WiringError(f"Cannot read refs/heads/main ({status}: {ref}). "
+                          f"Was the repo initialised?")
+    base = ref["object"]["sha"]
+    for branch in branches:
+        status, detail = call(token, "POST", f"/repos/{owner}/{repo}/git/refs",
+                              {"ref": f"refs/heads/{branch}", "sha": base})
+        report["branches"][branch] = ("created" if status < 400
+                                      else f"exists or refused ({status})")
+
+    token, _ = gh_token.mint(
+        account, [name], {"administration": "write", "metadata": "read"},
+        reason=f"bootstrap {owner}/{repo}: default branch and branch protection")
+    status, body = call(token, "PATCH", f"/repos/{owner}/{repo}",
+                        {"default_branch": default})
+    if status >= 400:
+        raise WiringError(f"Could not set the default branch ({status}: {body}).")
+    report["default_branch"] = body["default_branch"]
+    for branch in protect:
+        status, body = call(token, "POST", f"/repos/{owner}/{repo}/rulesets",
+                            ruleset_payload(branch))
+        report["protected"][branch] = {"ruleset_api": status}
+
+    # Verify what GitHub enforces, not what it accepted.
+    token, _ = gh_token.mint(account, [name], {"contents": "write",
+                                               "metadata": "read"})
+    for branch in protect:
+        protected, detail = is_protected(token, owner, repo, branch)
+        report["protected"][branch]["enforced"] = protected
+        report["protected"][branch]["probe"] = detail
+        if not protected:
+            report["unprotected"].append(branch)
+    return report
+
+
+def summarise(report):
+    lines = [f"Wired {report['repo']}: default branch "
+             f"{report['default_branch']!r}, branches "
+             f"{', '.join(sorted(report['branches']))}."]
+    for branch, state in sorted(report["protected"].items()):
+        verdict = "ENFORCED" if state.get("enforced") else "NOT ENFORCED"
+        lines.append(f"  {branch}: {verdict} — probe {state.get('probe')} "
+                     f"(rulesets API returned {state['ruleset_api']})")
+    if report["unprotected"]:
+        lines.append("")
+        lines.append("PROCESS-ONLY ENFORCEMENT on: "
+                     + ", ".join(report["unprotected"]) + ".")
+        lines.append("Rulesets are unavailable here — on the free plan they "
+                     "cover public repositories only, and org-level rulesets "
+                     "need Enterprise. Nothing in GitHub will stop a direct "
+                     "push to those branches; the human-only merge rule is "
+                     "carried by process alone.")
+        lines.append("Record this in the repo's CLAUDE.md and the needs-Steve "
+                     "digest. It is an accepted outcome, not a silent one.")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--repo", required=True, metavar="OWNER/NAME")
+    parser.add_argument("--checkout", required=True,
+                        help="path to the repo's working copy (holds scripts/)")
+    parser.add_argument("--default", default="dev")
+    parser.add_argument("--branches", default="dev,staging")
+    parser.add_argument("--protect", default="main,staging")
+    parser.add_argument("--json", action="store_true", help="emit the raw report")
+    args = parser.parse_args(argv)
+
+    if "/" not in args.repo:
+        parser.error("--repo takes OWNER/NAME")
+    owner, name = args.repo.split("/", 1)
+    split = lambda s: tuple(x.strip() for x in s.split(",") if x.strip())
+    try:
+        report = wire(owner, name, args.checkout, args.default,
+                      split(args.branches), split(args.protect))
+    except Exception as err:
+        print(f"WIRING FAILURE — the repo may be partly wired.\n{err}",
+              file=sys.stderr)
+        return 4
+    print(json.dumps(report, indent=2) if args.json else summarise(report))
+    return 5 if report["unprotected"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -25,11 +25,16 @@ description: Start-of-session orientation — one cheap read of the standing han
    from sofa-claude `main`'s `.claude/skills/` (compare via `gh`), refresh
    the copies from merged `main` — never from a branch — before relying on
    any skill.
-6. Credential presence check: confirm the App key is readable
-   (`test -r ~/.config/sofa-claude/app.pem`) and that `SOFA_APP_ID` is
-   set. **Presence only — never read, print, or echo a key or token.** If
-   either is missing, say so before starting work: every scripted GitHub
-   path stops without them, and finding that out mid-unit wastes the unit.
+6. Credential presence check: confirm the key `gh_token.py` will
+   actually use is readable — the file named by `SOFA_APP_KEY` when that
+   is set, else `~/.config/sofa-claude/app.pem`
+   (`test -r "${SOFA_APP_KEY:-$HOME/.config/sofa-claude/app.pem}"`) —
+   and that `SOFA_APP_ID` is set. **Presence only — never read, print,
+   or echo a key or token.** If either is missing, say so before
+   starting work: every scripted GitHub path stops without them, and
+   finding that out mid-unit wastes the unit. This is an operator
+   convenience, not a Grant 1 rail — it neither notifies nor halts, and
+   does not count toward that grant's notify-and-halt precondition.
 
 Do not deep-read decision records, grants, or history reflexively — pull
 them in only when the confirmed scope needs them.

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -5,19 +5,31 @@ description: Start-of-session orientation — one cheap read of the standing han
 
 # onboard
 
-1. Read the **body only** of Issue #1 (`gh issue view 1 --json body`). The
-   body is the whole handoff — GitHub's edit history preserves prior
-   versions; there is no comment log.
-2. Sanity-check the body against `git log --oneline -10` on `main` and the
+1. Resolve the handoff issue from **this repo's** CLAUDE.md, which names
+   it ("Standing handoff: Issue N"); in sofa-claude itself that is Issue
+   #1. Never assume #1 — in a workload repo it is whatever bootstrap
+   filled in, and #1 there is ordinary work. If CLAUDE.md names no handoff
+   issue, stop and say so rather than guessing.
+2. Read the **body only** of that issue (`gh issue view N --json
+   body,labels`). Confirm it carries `standing` before treating it as the
+   handoff; an issue without that label is not one. The body is the whole
+   handoff — GitHub's edit history preserves prior versions; there is no
+   comment log.
+3. Sanity-check the body against `git log --oneline -10` on `main` and the
    open-PR list. If the handoff predates visible activity, say so — treat
    the repo and GitHub as truth, the handoff as a pointer.
-3. State your understanding of current scope in two or three sentences and
+4. State your understanding of current scope in two or three sentences and
    confirm it with Steve (or, in an unattended run, against the schedule's
    declared purpose). Only then read anything else or act.
-4. Freshness check on the operator toolbox: if `~/.claude/skills/` differs
+5. Freshness check on the operator toolbox: if `~/.claude/skills/` differs
    from sofa-claude `main`'s `.claude/skills/` (compare via `gh`), refresh
    the copies from merged `main` — never from a branch — before relying on
    any skill.
+6. Credential presence check: confirm the App key is readable
+   (`test -r ~/.config/sofa-claude/app.pem`) and that `SOFA_APP_ID` is
+   set. **Presence only — never read, print, or echo a key or token.** If
+   either is missing, say so before starting work: every scripted GitHub
+   path stops without them, and finding that out mid-unit wastes the unit.
 
 Do not deep-read decision records, grants, or history reflexively — pull
 them in only when the confirmed scope needs them.

--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -5,36 +5,47 @@ description: Start-of-session orientation — one cheap read of the standing han
 
 # onboard
 
-1. Resolve the handoff issue from **this repo's** CLAUDE.md, which names
+Every `gh` call in this skill runs under a short-lived App token minted
+by the repo's credential helper — in a workload repo
+`python3 scripts/gh_token.py --account <owner> --repos <name>
+--perm <name=level> -- gh ...`; in sofa-claude itself the helper lives
+at `seed/scripts/gh_token.py` — never ambient session auth. Grant 4's
+regime has no ambient fallback.
+
+1. Credential presence check, before the first `gh` call: confirm the
+   key `gh_token.py` will actually use is readable — the file named by
+   `SOFA_APP_KEY` when that is set, else `~/.config/sofa-claude/app.pem`
+   (`test -r "${SOFA_APP_KEY:-$HOME/.config/sofa-claude/app.pem}"`) —
+   and that `SOFA_APP_ID` is set. **Presence only — never read, print,
+   or echo a key or token.** If either is missing, say so before
+   starting work: every GitHub path in this session stops without them,
+   and finding that out mid-unit wastes the unit. This is an operator
+   convenience, not a Grant 1 rail — it neither notifies nor halts, and
+   does not count toward that grant's notify-and-halt precondition.
+2. Resolve the handoff issue from **this repo's** CLAUDE.md, which names
    it ("Standing handoff: Issue N"); in sofa-claude itself that is Issue
    #1. Never assume #1 — in a workload repo it is whatever bootstrap
    filled in, and #1 there is ordinary work. If CLAUDE.md names no handoff
    issue, stop and say so rather than guessing.
-2. Read the **body only** of that issue (`gh issue view N --json
-   body,labels`). Confirm it carries `standing` before treating it as the
+3. Read the **body only** of that issue
+   (`... --perm issues=read -- gh issue view N --json body,labels`).
+   Confirm it carries `standing` before treating it as the
    handoff; an issue without that label is not one. The body is the whole
    handoff — GitHub's edit history preserves prior versions; there is no
    comment log.
-3. Sanity-check the body against `git log --oneline -10` on `main` and the
+4. Sanity-check the body against `git log --oneline -10` on `main` and the
    open-PR list. If the handoff predates visible activity, say so — treat
    the repo and GitHub as truth, the handoff as a pointer.
-4. State your understanding of current scope in two or three sentences and
+5. State your understanding of current scope in two or three sentences and
    confirm it with Steve (or, in an unattended run, against the schedule's
    declared purpose). Only then read anything else or act.
-5. Freshness check on the operator toolbox: if `~/.claude/skills/` differs
-   from sofa-claude `main`'s `.claude/skills/` (compare via `gh`), refresh
-   the copies from merged `main` — never from a branch — before relying on
-   any skill.
-6. Credential presence check: confirm the key `gh_token.py` will
-   actually use is readable — the file named by `SOFA_APP_KEY` when that
-   is set, else `~/.config/sofa-claude/app.pem`
-   (`test -r "${SOFA_APP_KEY:-$HOME/.config/sofa-claude/app.pem}"`) —
-   and that `SOFA_APP_ID` is set. **Presence only — never read, print,
-   or echo a key or token.** If either is missing, say so before
-   starting work: every scripted GitHub path stops without them, and
-   finding that out mid-unit wastes the unit. This is an operator
-   convenience, not a Grant 1 rail — it neither notifies nor halts, and
-   does not count toward that grant's notify-and-halt precondition.
+6. Freshness check on the operator toolbox: if `~/.claude/skills/` differs
+   from sofa-claude `main`'s `.claude/skills/` (compare via a
+   `--account smansf --repos sofa-claude --perm contents=read` mint),
+   refresh the copies from merged `main` — **each skill's whole
+   directory, not just SKILL.md** (bootstrap ships `wire_repo.py` beside
+   its SKILL.md, and the documented invocation runs it from the
+   installed path) — never from a branch — before relying on any skill.
 
 Do not deep-read decision records, grants, or history reflexively — pull
 them in only when the confirmed scope needs them.

--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -11,10 +11,16 @@ description: End-of-session handoff — drain in-flight work, reconcile issue st
    touched this session reflect reality; anything discovered but not filed
    was *deliberately* dropped per the intake kill step (do not file a
    parting wave of findings — that is the legacy failure mode).
-3. Overwrite the **body** of Issue #1 with: current state, in-flight PRs,
-   the next session's starting point. Append nothing; the body is the whole
-   handoff.
-4. Refresh the **body** of Issue #2 (needs-Steve digest): list only items
+3. Overwrite the **body** of the handoff issue named in **this repo's**
+   CLAUDE.md — in sofa-claude that is Issue #1, in a workload repo it is
+   whatever bootstrap filled in. **Confirm it carries `standing` before
+   writing**, and stop if it does not: overwriting a body is destructive
+   and there is no comment log to recover from, so writing to a guessed
+   number would silently destroy someone's unrelated issue. Content:
+   current state, in-flight PRs, the next session's starting point.
+   Append nothing; the body is the whole handoff.
+4. Refresh the **body** of the needs-Steve digest issue (Issue #2 in
+   sofa-claude), under the same `standing`-label guard: list only items
    genuinely blocked on Steve — pending merges/promotions, open grant
    decisions, halted runs — each with its paste-ready command where one
    applies (e.g. `/code-review high <PR URL> --comment`). An empty list is

--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -5,6 +5,13 @@ description: End-of-session handoff — drain in-flight work, reconcile issue st
 
 # wrap-up
 
+Every `gh` call in this skill runs under a short-lived App token minted
+by the repo's credential helper — in a workload repo
+`python3 scripts/gh_token.py --account <owner> --repos <name>
+--perm <name=level> -- gh ...`; in sofa-claude itself the helper lives
+at `seed/scripts/gh_token.py` — never ambient session auth. Grant 4's
+regime has no ambient fallback.
+
 1. Drain or explicitly hand off any in-flight background work; nothing
    should be silently mid-air when the session ends.
 2. Reconcile GitHub state: every pushed `claude/*` branch has a PR; issues
@@ -22,7 +29,14 @@ description: End-of-session handoff — drain in-flight work, reconcile issue st
 4. Refresh the **body** of the needs-Steve digest issue — **always
    sofa-claude's own** (Issue #2 in smansf/sofa-claude), whatever repo
    the session ran in: the digest aggregates across repos, and workload
-   repos carry none of their own. Same `standing`-label guard: list only
+   repos carry none of their own. From a workload repo this is the one
+   write that leaves the repo's scope — mint for it explicitly:
+   `python3 scripts/gh_token.py --account smansf --repos sofa-claude
+   --perm issues=write --reason "needs-Steve digest" -- gh issue edit 2
+   --repo smansf/sofa-claude --body-file ...`. If that mint fails, the
+   App's smansf installation does not cover sofa-claude — put the digest
+   content in the recap for Steve instead of writing nothing silently.
+   Same `standing`-label guard: list only
    items genuinely blocked on Steve — pending merges/promotions, open grant
    decisions, halted runs — each with its paste-ready command where one
    applies (e.g. `/code-review high <PR URL> --comment`). An empty list is

--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -19,9 +19,11 @@ description: End-of-session handoff — drain in-flight work, reconcile issue st
    number would silently destroy someone's unrelated issue. Content:
    current state, in-flight PRs, the next session's starting point.
    Append nothing; the body is the whole handoff.
-4. Refresh the **body** of the needs-Steve digest issue (Issue #2 in
-   sofa-claude), under the same `standing`-label guard: list only items
-   genuinely blocked on Steve — pending merges/promotions, open grant
+4. Refresh the **body** of the needs-Steve digest issue — **always
+   sofa-claude's own** (Issue #2 in smansf/sofa-claude), whatever repo
+   the session ran in: the digest aggregates across repos, and workload
+   repos carry none of their own. Same `standing`-label guard: list only
+   items genuinely blocked on Steve — pending merges/promotions, open grant
    decisions, halted runs — each with its paste-ready command where one
    applies (e.g. `/code-review high <PR URL> --comment`). An empty list is
    a valid and good state. End the digest with one line — the current count

--- a/governance/grants.md
+++ b/governance/grants.md
@@ -66,7 +66,11 @@ then the PAT rules stand and this grant is inert.
   Issues #22, #23). Until those PRs merge, a declared credential no code
   calls is prose, not a rail (decisions/0003), and merging this grant
   alone would raise the App's ceiling before the control that answers it
-  is load-bearing.
+  is load-bearing. **Activation is one beat, not a merge alone:** the
+  merge that satisfies these preconditions, the revocation of the PAT,
+  and the matching rewrite of `~/.claude/CLAUDE.md` happen together —
+  from then on an interactive session's `gh` also runs under
+  per-invocation minted tokens, and no PAT survives as a fallback.
 
 - The GitHub surface is a GitHub App (`sofa-claude-ops`), not a personal
   access token. Its private key lives outside any repository, mode 600,
@@ -121,10 +125,16 @@ then the PAT rules stand and this grant is inert.
   platform config sitting inside the same permission bootstrap needs to
   create it, so a wiring token can strip the gate, after which an ordinary
   `contents` token merges to `main` without breaching any rule stated
-  here. Bootstrap therefore verifies protection by behaviour — attempting
-  a write and requiring the refusal — never by trusting a success code
-  (Issue #23). GitHub bundles repository deletion into the same
-  permission and does not let us split it off.
+  here. Bootstrap therefore verifies protection rather than trusting a
+  success code (Issue #23): the push path by behaviour — attempting a
+  write and requiring a refusal *by rules*, an error never counting —
+  and the merge path by reading back the rules GitHub reports as
+  applying, requiring at least one approving human review. The merge
+  path gets a read-back, not a behavioural probe, because its
+  behavioural test is an actual merge — which is how the zero-approval
+  hole was demonstrated on a throwaway repo (PR #32, finding 1). GitHub
+  bundles repository deletion into the same permission and does not let
+  us split it off.
 
 - **The widening is recorded, not glossed.** Steve granted the App
   organization-level Administration on `warblersafety` (2026-08-20),

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -54,9 +54,11 @@ refreshes it.
   credentials. Claude never merges to `staging` or `main`.
 - Every GitHub call from this repo — `scripts/merge_dev.py`, or a
   session's own `gh` — runs under a short-lived App token minted by
-  `scripts/gh_token.py`, scoped to this repo and to the permissions the
-  task needs (`python3 scripts/gh_token.py --account <owner> --repos
-  <name> --perm contents=read -- gh ...`). There is no ambient fallback:
+  `scripts/gh_token.py`, scoped to the repositories and permissions the
+  task actually touches — usually this repo (`python3 scripts/gh_token.py
+  --account <owner> --repos <name> --perm contents=read -- gh ...`); the
+  needs-Steve digest write is the standing exception (`--account smansf
+  --repos sofa-claude --perm issues=write`). There is no ambient fallback:
   if minting fails, that work stops and the cause goes to the needs-Steve
   digest; never retry under another credential, and never `gh auth
   login`. This repo requires no PAT of its own.

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -40,8 +40,14 @@ refreshes it.
   deletes `staging`. If it reports `true` the promotion waits: it is a
   needs-Steve item (Settings → General, ~15 s), and `scripts/merge_dev.py`
   already deletes unit branches itself, so nothing here needs the setting.
-  Protected `staging`/`main` are exempt, but branch protection is not
-  available on private repos at this plan — do not rely on it.
+  Protected `staging`/`main` are exempt from that deletion, but see the
+  next line before assuming they are protected at all.
+- **Branch protection in this repo: {{ENFORCEMENT}}** — filled at bootstrap
+  from `wire_repo.py`'s probe, which tests what GitHub refuses rather than
+  what its API accepted. Free-plan rulesets cover **public** repos only, so
+  a private repo is wired but unprotected and the human-only merge rule on
+  `staging`/`main` rests on process alone. Whichever this repo got, it is
+  recorded here so the distinction outlives the session that made it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
 - Scripted GitHub access — `scripts/merge_dev.py` today — takes its

--- a/seed/CLAUDE.md.template
+++ b/seed/CLAUDE.md.template
@@ -43,20 +43,23 @@ refreshes it.
   Protected `staging`/`main` are exempt from that deletion, but see the
   next line before assuming they are protected at all.
 - **Branch protection in this repo: {{ENFORCEMENT}}** — filled at bootstrap
-  from `wire_repo.py`'s probe, which tests what GitHub refuses rather than
-  what its API accepted. Free-plan rulesets cover **public** repos only, so
-  a private repo is wired but unprotected and the human-only merge rule on
-  `staging`/`main` rests on process alone. Whichever this repo got, it is
-  recorded here so the distinction outlives the session that made it.
+  from `wire_repo.py`'s verification of both paths: a direct push must be
+  refused *by rules*, and the rules GitHub reports as applying must gate
+  merges on at least one approving human review (zero required approvals
+  requires a PR, not a human). Free-plan rulesets cover **public** repos
+  only, so a private repo is wired but unprotected and the human-only merge
+  rule on `staging`/`main` rests on process alone. Whichever this repo got,
+  it is recorded here so the distinction outlives the session that made it.
 - Deploy wiring lives in Steve's Vercel account; Claude holds no Vercel
   credentials. Claude never merges to `staging` or `main`.
-- Scripted GitHub access — `scripts/merge_dev.py` today — takes its
-  credential from `scripts/gh_token.py`: a short-lived App token scoped to
-  this repo and to the permissions that task needs. If minting fails, that
-  work stops and the cause goes to the needs-Steve digest; never retry
-  under another credential, and never `gh auth login`. Interactive `gh`
-  still runs on the session's ambient auth until sofa-claude #23 lands.
-  This repo requires no PAT of its own.
+- Every GitHub call from this repo — `scripts/merge_dev.py`, or a
+  session's own `gh` — runs under a short-lived App token minted by
+  `scripts/gh_token.py`, scoped to this repo and to the permissions the
+  task needs (`python3 scripts/gh_token.py --account <owner> --repos
+  <name> --perm contents=read -- gh ...`). There is no ambient fallback:
+  if minting fails, that work stops and the cause goes to the needs-Steve
+  digest; never retry under another credential, and never `gh auth
+  login`. This repo requires no PAT of its own.
 - Promote often: a `dev` far ahead of `staging` makes promotion scary
   instead of routine. Claude flags when the gap exceeds ~10 units.
 

--- a/tests/test_wire_repo.py
+++ b/tests/test_wire_repo.py
@@ -1,0 +1,136 @@
+"""Tests for bootstrap's repo wiring and its protection probe.
+
+The property under test is that wiring reports what GitHub *enforces*,
+not what its APIs accepted — a 201 from the rulesets endpoint means a
+ruleset was recorded, not that a branch is protected. On the free plan a
+private repo gets no rulesets at all, so "unprotected" is a normal
+outcome; the requirement is that it can never be a quiet one.
+"""
+
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+_path = (pathlib.Path(__file__).resolve().parent.parent
+         / ".claude" / "skills" / "bootstrap" / "wire_repo.py")
+_spec = importlib.util.spec_from_file_location("wire_repo", _path)
+wire_repo = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wire_repo)
+
+
+class ProbeTests(unittest.TestCase):
+    """The probe must create nothing, whichever answer it gets."""
+
+    def _probe(self, patch_status, patch_detail=""):
+        calls = []
+
+        def fake_call(token, method, path, payload=None):
+            calls.append((method, path, payload))
+            if method == "GET":
+                return 200, {"object": {"sha": "abc123"}}
+            return patch_status, patch_detail
+
+        with mock.patch.object(wire_repo, "call", fake_call):
+            result = wire_repo.is_protected("t", "o", "r", "main")
+        return result, calls
+
+    def test_refused_write_means_protected(self):
+        (protected, detail), _ = self._probe(422, "Repository rule violations found")
+        self.assertTrue(protected)
+        self.assertIn("refused", detail)
+
+    def test_accepted_write_means_unprotected(self):
+        (protected, detail), _ = self._probe(200)
+        self.assertFalse(protected)
+        self.assertIn("ACCEPTED", detail)
+
+    def test_probe_is_a_no_op_fast_forward(self):
+        """Points the ref at the sha it already holds: no commit, no file."""
+        _, calls = self._probe(422)
+        methods = [c[0] for c in calls]
+        self.assertEqual(methods, ["GET", "PATCH"])
+        self.assertNotIn("PUT", methods, "a contents write would leave junk behind")
+        self.assertEqual(calls[1][2], {"sha": "abc123", "force": False})
+
+    def test_unreadable_branch_is_not_reported_as_protected(self):
+        """Absence of an answer must never read as protection."""
+        with mock.patch.object(wire_repo, "call",
+                               lambda *a, **k: (404, "Not Found")):
+            protected, detail = wire_repo.is_protected("t", "o", "r", "main")
+        self.assertFalse(protected)
+        self.assertIn("not readable", detail)
+
+
+class SeedCopyTests(unittest.TestCase):
+    def test_missing_credential_path_stops_wiring(self):
+        """A repo wired without gh_token.py could never merge anything."""
+        with self.assertRaises(wire_repo.WiringError) as caught:
+            wire_repo.load_gh_token("/nonexistent/checkout")
+        message = str(caught.exception)
+        self.assertIn("gh_token.py", message)
+        self.assertIn("seed copy is incomplete", message)
+
+
+class ReportingTests(unittest.TestCase):
+    UNPROTECTED = {
+        "repo": "warblersafety/wilson", "default_branch": "dev",
+        "branches": {"dev": "created", "staging": "created"},
+        "protected": {
+            "main": {"ruleset_api": 403, "enforced": False,
+                     "probe": "a direct write to this branch was ACCEPTED"},
+            "staging": {"ruleset_api": 403, "enforced": False,
+                        "probe": "a direct write to this branch was ACCEPTED"}},
+        "unprotected": ["main", "staging"]}
+
+    PROTECTED = {
+        "repo": "warblersafety/scratch", "default_branch": "dev",
+        "branches": {"dev": "created", "staging": "created"},
+        "protected": {"main": {"ruleset_api": 201, "enforced": True,
+                               "probe": "refused (422)"}},
+        "unprotected": []}
+
+    def test_unprotected_repo_is_reported_loudly(self):
+        text = wire_repo.summarise(self.UNPROTECTED)
+        self.assertIn("NOT ENFORCED", text)
+        self.assertIn("PROCESS-ONLY ENFORCEMENT", text)
+        self.assertIn("needs-Steve digest", text)
+        self.assertIn("CLAUDE.md", text)
+
+    def test_protected_repo_says_so_without_the_warning(self):
+        text = wire_repo.summarise(self.PROTECTED)
+        self.assertIn("ENFORCED", text)
+        self.assertNotIn("PROCESS-ONLY", text)
+
+    def test_a_recorded_ruleset_is_not_reported_as_protection(self):
+        """201 from the rulesets API must not be mistaken for enforcement."""
+        report = dict(self.PROTECTED)
+        report["protected"] = {"main": {"ruleset_api": 201, "enforced": False,
+                                        "probe": "a direct write was ACCEPTED"}}
+        report["unprotected"] = ["main"]
+        text = wire_repo.summarise(report)
+        self.assertIn("NOT ENFORCED", text)
+        self.assertIn("PROCESS-ONLY ENFORCEMENT", text)
+
+    def test_exit_code_distinguishes_unprotected_from_clean(self):
+        for report, expected in ((self.PROTECTED, 0), (self.UNPROTECTED, 5)):
+            with self.subTest(repo=report["repo"]):
+                with mock.patch.object(wire_repo, "wire", return_value=report), \
+                     mock.patch.object(sys, "stdout", io.StringIO()):
+                    code = wire_repo.main(["--repo", report["repo"],
+                                           "--checkout", "/tmp"])
+                self.assertEqual(code, expected)
+
+    def test_wiring_failure_exits_4_not_5(self):
+        with mock.patch.object(wire_repo, "wire",
+                               side_effect=wire_repo.WiringError("boom")), \
+             mock.patch.object(sys, "stderr", io.StringIO()):
+            self.assertEqual(wire_repo.main(["--repo", "o/r",
+                                             "--checkout", "/tmp"]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wire_repo.py
+++ b/tests/test_wire_repo.py
@@ -1,10 +1,14 @@
-"""Tests for bootstrap's repo wiring and its protection probe.
+"""Tests for bootstrap's repo wiring and its protection verification.
 
 The property under test is that wiring reports what GitHub *enforces*,
 not what its APIs accepted — a 201 from the rulesets endpoint means a
-ruleset was recorded, not that a branch is protected. On the free plan a
-private repo gets no rulesets at all, so "unprotected" is a normal
-outcome; the requirement is that it can never be a quiet one.
+ruleset was recorded, not that a branch is protected, and an errored
+probe means "could not verify", never "protected". Protection itself
+means both paths: direct pushes refused by rules, and merges gated on at
+least one approving human review — a zero-approval rule requires a PR,
+not a human (PR #32, finding 1). On the free plan a private repo gets no
+rulesets at all, so "unprotected" is a normal outcome; the requirement
+is that it can never be a quiet one.
 """
 
 import importlib.util
@@ -22,8 +26,21 @@ wire_repo = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(wire_repo)
 
 
-class ProbeTests(unittest.TestCase):
-    """The probe must create nothing, whichever answer it gets."""
+class PayloadTests(unittest.TestCase):
+    def test_ruleset_requires_a_human_approval(self):
+        """Zero approvals requires a PR, not a human (finding 1)."""
+        payload = wire_repo.ruleset_payload("main")
+        pull = [r for r in payload["rules"] if r["type"] == "pull_request"]
+        self.assertEqual(len(pull), 1)
+        self.assertGreaterEqual(
+            pull[0]["parameters"]["required_approving_review_count"], 1)
+
+    def test_nobody_bypasses(self):
+        self.assertEqual(wire_repo.ruleset_payload("main")["bypass_actors"], [])
+
+
+class PushProbeTests(unittest.TestCase):
+    """The probe must create nothing, and an error is never a refusal."""
 
     def _probe(self, patch_status, patch_detail=""):
         calls = []
@@ -35,44 +52,189 @@ class ProbeTests(unittest.TestCase):
             return patch_status, patch_detail
 
         with mock.patch.object(wire_repo, "call", fake_call):
-            result = wire_repo.is_protected("t", "o", "r", "main")
+            result = wire_repo.push_refused("t", "o", "r", "main")
         return result, calls
 
-    def test_refused_write_means_protected(self):
-        (protected, detail), _ = self._probe(422, "Repository rule violations found")
-        self.assertTrue(protected)
+    def test_rules_refusal_means_protected(self):
+        (verdict, detail), _ = self._probe(422, "Repository rule violations found")
+        self.assertIs(verdict, True)
         self.assertIn("refused", detail)
 
     def test_accepted_write_means_unprotected(self):
-        (protected, detail), _ = self._probe(200)
-        self.assertFalse(protected)
+        (verdict, detail), _ = self._probe(200)
+        self.assertIs(verdict, False)
         self.assertIn("ACCEPTED", detail)
 
     def test_probe_is_a_no_op_fast_forward(self):
         """Points the ref at the sha it already holds: no commit, no file."""
-        _, calls = self._probe(422)
+        _, calls = self._probe(422, "Repository rule violations found")
         methods = [c[0] for c in calls]
         self.assertEqual(methods, ["GET", "PATCH"])
         self.assertNotIn("PUT", methods, "a contents write would leave junk behind")
         self.assertEqual(calls[1][2], {"sha": "abc123", "force": False})
 
+    def test_errors_are_not_refusals(self):
+        """A 500, a rate limit, a dead token, an unrelated 422: could not
+        verify — never 'protected' (finding 3)."""
+        for status, detail in ((500, "boom"), (429, "rate limited"),
+                               (401, "Bad credentials"),
+                               (403, "Resource not accessible"),
+                               (422, "Validation Failed")):
+            with self.subTest(status=status):
+                (verdict, text), _ = self._probe(status, detail)
+                self.assertIsNone(verdict)
+                self.assertIn("inconclusive", text)
+
     def test_unreadable_branch_is_not_reported_as_protected(self):
         """Absence of an answer must never read as protection."""
         with mock.patch.object(wire_repo, "call",
                                lambda *a, **k: (404, "Not Found")):
-            protected, detail = wire_repo.is_protected("t", "o", "r", "main")
-        self.assertFalse(protected)
+            verdict, detail = wire_repo.push_refused("t", "o", "r", "main")
+        self.assertIsNone(verdict)
         self.assertIn("not readable", detail)
+
+
+class MergeGateTests(unittest.TestCase):
+    """The merge gate is read from the rules GitHub reports as applying."""
+
+    def _gate(self, status, rules):
+        with mock.patch.object(wire_repo, "call",
+                               lambda *a, **k: (status, rules)):
+            return wire_repo.merge_gate("t", "o", "r", "main")
+
+    def test_one_required_approval_is_a_gate(self):
+        verdict, _ = self._gate(200, [
+            {"type": "pull_request",
+             "parameters": {"required_approving_review_count": 1}}])
+        self.assertIs(verdict, True)
+
+    def test_zero_required_approvals_is_not_a_gate(self):
+        """The demonstrated hole: a PR is required, a human is not."""
+        verdict, detail = self._gate(200, [
+            {"type": "pull_request",
+             "parameters": {"required_approving_review_count": 0}}])
+        self.assertIs(verdict, False)
+        self.assertIn("0 approving", detail)
+
+    def test_no_applying_rule_is_not_a_gate(self):
+        verdict, _ = self._gate(200, [{"type": "deletion"}])
+        self.assertIs(verdict, False)
+
+    def test_the_free_plan_answer_is_a_definite_no_not_an_error(self):
+        """Verified live 2026-08-20: a private free-plan repo answers rule
+        reads with 403 and its upgrade message. That is the plan
+        limitation positively identified — it must not exit 4."""
+        verdict, detail = self._gate(
+            403, "Upgrade to GitHub Pro or make this repository public "
+                 "to enable this feature.")
+        self.assertIs(verdict, False)
+        self.assertIn("unavailable on this plan", detail)
+
+    def test_any_other_error_is_not_a_verdict(self):
+        for status, body in ((500, "boom"), (403, "Resource not accessible"),
+                             (429, "rate limited")):
+            with self.subTest(status=status):
+                verdict, _ = self._gate(status, body)
+                self.assertIsNone(verdict)
 
 
 class SeedCopyTests(unittest.TestCase):
     def test_missing_credential_path_stops_wiring(self):
-        """A repo wired without gh_token.py could never merge anything."""
+        """A repo wired without gh_token.py could never merge anything —
+        and the message names the wrong-directory cause (finding 7)."""
         with self.assertRaises(wire_repo.WiringError) as caught:
             wire_repo.load_gh_token("/nonexistent/checkout")
         message = str(caught.exception)
         self.assertIn("gh_token.py", message)
         self.assertIn("seed copy is incomplete", message)
+        self.assertIn("workload repo's root", message)
+
+
+class WireTests(unittest.TestCase):
+    """wire() stops loudly, and what it raises carries the partial report."""
+
+    class FakeTokens:
+        @staticmethod
+        def mint(account, repositories, permissions, reason=None):
+            return "tok", None
+
+    def _wire(self, responses, branches=("dev", "staging"), protect=()):
+        """responses: {(method, path-suffix): [answers]} — an answer queue
+        per endpoint; the last answer repeats."""
+
+        def fake_call(token, method, path, payload=None):
+            for (m, suffix), answers in responses.items():
+                if m == method and path.endswith(suffix):
+                    return answers.pop(0) if len(answers) > 1 else answers[0]
+            raise AssertionError(f"unexpected call {method} {path}")
+
+        with mock.patch.object(wire_repo, "load_gh_token",
+                               return_value=self.FakeTokens), \
+             mock.patch.object(wire_repo, "call", fake_call):
+            return wire_repo.wire("o", "r", "/anywhere",
+                                  branches=branches, protect=protect)
+
+    def test_an_existing_branch_is_recorded_not_failed(self):
+        report = self._wire({
+            ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+            ("POST", "/git/refs"): [(201, {}), (422, "Reference already exists")],
+            ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+        })
+        self.assertEqual(report["branches"],
+                         {"dev": "created", "staging": "already existed"})
+
+    def test_a_failed_branch_creation_stops_wiring_loudly(self):
+        """Finding 5: carrying on would turn a missing branch into a
+        'plan limitation' in the permanent record."""
+        with self.assertRaises(wire_repo.WiringError) as caught:
+            self._wire({
+                ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+                ("POST", "/git/refs"): [(201, {}), (403, "Forbidden")],
+            })
+        self.assertIn("staging", str(caught.exception))
+        self.assertEqual(caught.exception.report["branches"]["dev"], "created")
+
+    def test_failure_carries_the_partial_report(self):
+        """Finding 4: exit 4 must be able to say exactly what was done."""
+        with self.assertRaises(wire_repo.WiringError) as caught:
+            self._wire({
+                ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+                ("POST", "/git/refs"): [(201, {})],
+                ("PATCH", "/repos/o/r"): [(500, "boom")],
+            }, branches=("dev",))
+        self.assertEqual(caught.exception.report["branches"], {"dev": "created"})
+        self.assertIsNone(caught.exception.report["default_branch"])
+
+    def test_inconclusive_verification_is_a_failure_not_a_verdict(self):
+        """Finding 3 end to end: an errored probe must become exit 4 —
+        never ENFORCED (exit 0), never an accepted outcome (exit 5)."""
+        with self.assertRaises(wire_repo.WiringError) as caught:
+            self._wire({
+                ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+                ("POST", "/git/refs"): [(201, {})],
+                ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+                ("POST", "/rulesets"): [(201, {})],
+                ("PATCH", "/git/refs/heads/main"): [(500, "boom")],
+                ("GET", "/rules/branches/main"): [(200, [])],
+            }, branches=("dev",), protect=("main",))
+        self.assertIn("could not be verified", str(caught.exception))
+
+    def test_enforced_needs_both_paths(self):
+        """A refused push with a zero-approval merge rule is the
+        demonstrated hole, and must land in unprotected (finding 1)."""
+        report = self._wire({
+            ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+            ("POST", "/git/refs"): [(201, {})],
+            ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("POST", "/rulesets"): [(201, {})],
+            ("PATCH", "/git/refs/heads/main"):
+                [(422, "Repository rule violations found")],
+            ("GET", "/rules/branches/main"): [(200, [
+                {"type": "pull_request",
+                 "parameters": {"required_approving_review_count": 0}}])],
+        }, branches=("dev",), protect=("main",))
+        self.assertFalse(report["protected"]["main"]["enforced"])
+        self.assertEqual(report["unprotected"], ["main"])
 
 
 class ReportingTests(unittest.TestCase):
@@ -81,16 +243,22 @@ class ReportingTests(unittest.TestCase):
         "branches": {"dev": "created", "staging": "created"},
         "protected": {
             "main": {"ruleset_api": 403, "enforced": False,
-                     "probe": "a direct write to this branch was ACCEPTED"},
+                     "push": "a direct write to this branch was ACCEPTED",
+                     "merge": "rules unavailable on this plan for this repo"},
             "staging": {"ruleset_api": 403, "enforced": False,
-                        "probe": "a direct write to this branch was ACCEPTED"}},
+                        "push": "a direct write to this branch was ACCEPTED",
+                        "merge": "rules unavailable on this plan for this repo"}},
         "unprotected": ["main", "staging"]}
 
     PROTECTED = {
         "repo": "warblersafety/scratch", "default_branch": "dev",
-        "branches": {"dev": "created", "staging": "created"},
-        "protected": {"main": {"ruleset_api": 201, "enforced": True,
-                               "probe": "refused (422)"}},
+        "branches": {"dev": "created", "staging": "already existed"},
+        "protected": {
+            "main": {"ruleset_api": 201, "enforced": True,
+                     "push": "refused by rules (422: Repository rule "
+                             "violations found)",
+                     "merge": "pull_request rule applies, 1 approving "
+                              "review(s) required"}},
         "unprotected": []}
 
     def test_unprotected_repo_is_reported_loudly(self):
@@ -105,15 +273,26 @@ class ReportingTests(unittest.TestCase):
         self.assertIn("ENFORCED", text)
         self.assertNotIn("PROCESS-ONLY", text)
 
-    def test_a_recorded_ruleset_is_not_reported_as_protection(self):
-        """201 from the rulesets API must not be mistaken for enforcement."""
+    def test_branch_statuses_are_visible(self):
+        """Finding 5: a name alone hides a branch that was never made."""
+        self.assertIn("staging (already existed)",
+                      wire_repo.summarise(self.PROTECTED))
+
+    def test_recorded_but_unenforced_is_an_anomaly_not_a_plan_limit(self):
+        """A 201 followed by no enforcement is not the free-plan story and
+        must never be recorded as an accepted outcome (findings 1, 5)."""
         report = dict(self.PROTECTED)
-        report["protected"] = {"main": {"ruleset_api": 201, "enforced": False,
-                                        "probe": "a direct write was ACCEPTED"}}
+        report["protected"] = {
+            "main": {"ruleset_api": 201, "enforced": False,
+                     "push": "a direct write to this branch was ACCEPTED",
+                     "merge": "no pull_request rule applies to this branch"}}
         report["unprotected"] = ["main"]
         text = wire_repo.summarise(report)
         self.assertIn("NOT ENFORCED", text)
-        self.assertIn("PROCESS-ONLY ENFORCEMENT", text)
+        self.assertIn("RECORDED BUT NOT ENFORCED", text)
+        self.assertIn("investigate", text)
+        self.assertNotIn("PROCESS-ONLY", text)
+        self.assertNotIn("accepted outcome", text)
 
     def test_exit_code_distinguishes_unprotected_from_clean(self):
         for report, expected in ((self.PROTECTED, 0), (self.UNPROTECTED, 5)):
@@ -124,12 +303,29 @@ class ReportingTests(unittest.TestCase):
                                            "--checkout", "/tmp"])
                 self.assertEqual(code, expected)
 
-    def test_wiring_failure_exits_4_not_5(self):
+    def test_wiring_failure_exits_4_and_lists_what_was_done(self):
+        """Finding 4: the failure output shows the partial state."""
+        err = wire_repo.WiringError("boom")
+        err.report = {"repo": "o/r", "default_branch": "dev",
+                      "branches": {"dev": "created"}, "protected": {},
+                      "unprotected": []}
+        stderr = io.StringIO()
+        with mock.patch.object(wire_repo, "wire", side_effect=err), \
+             mock.patch.object(sys, "stderr", stderr):
+            code = wire_repo.main(["--repo", "o/r", "--checkout", "/tmp"])
+        self.assertEqual(code, 4)
+        self.assertIn("may be partly wired", stderr.getvalue())
+        self.assertIn('"dev": "created"', stderr.getvalue())
+
+    def test_wiring_failure_before_any_change_says_so(self):
+        """Finding 4: when nothing was changed, exit 4 says exactly that."""
+        stderr = io.StringIO()
         with mock.patch.object(wire_repo, "wire",
-                               side_effect=wire_repo.WiringError("boom")), \
-             mock.patch.object(sys, "stderr", io.StringIO()):
-            self.assertEqual(wire_repo.main(["--repo", "o/r",
-                                             "--checkout", "/tmp"]), 4)
+                               side_effect=wire_repo.WiringError("no checkout")), \
+             mock.patch.object(sys, "stderr", stderr):
+            code = wire_repo.main(["--repo", "o/r", "--checkout", "/tmp"])
+        self.assertEqual(code, 4)
+        self.assertIn("Nothing had been changed yet", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_wire_repo.py
+++ b/tests/test_wire_repo.py
@@ -75,11 +75,16 @@ class PushProbeTests(unittest.TestCase):
 
     def test_errors_are_not_refusals(self):
         """A 500, a rate limit, a dead token, an unrelated 422: could not
-        verify — never 'protected' (finding 3)."""
+        verify — never 'protected' (finding 3). Classic branch
+        protection's refusal shapes are deliberately unlisted — this
+        script only ever creates rulesets, and an unverified shape must
+        land inconclusive-and-loud, not guessed as protection."""
         for status, detail in ((500, "boom"), (429, "rate limited"),
                                (401, "Bad credentials"),
                                (403, "Resource not accessible"),
-                               (422, "Validation Failed")):
+                               (422, "Validation Failed"),
+                               (422, "protected branch hook declined"),
+                               (403, "Refusing to update ref: protected branch")):
             with self.subTest(status=status):
                 (verdict, text), _ = self._probe(status, detail)
                 self.assertIsNone(verdict)
@@ -153,23 +158,32 @@ class SeedCopyTests(unittest.TestCase):
 class WireTests(unittest.TestCase):
     """wire() stops loudly, and what it raises carries the partial report."""
 
-    class FakeTokens:
-        @staticmethod
-        def mint(account, repositories, permissions, reason=None):
-            return "tok", None
+    REPO_OK = (200, {"default_branch": "dev", "delete_branch_on_merge": False})
 
     def _wire(self, responses, branches=("dev", "staging"), protect=()):
         """responses: {(method, path-suffix): [answers]} — an answer queue
-        per endpoint; the last answer repeats."""
+        per endpoint; the last answer repeats. Records every mint in
+        self.mints and every call's token in self.tokens_used."""
+        self.mints = []
+        self.tokens_used = []
+
+        outer = self
+
+        class FakeTokens:
+            @staticmethod
+            def mint(account, repositories, permissions, reason=None):
+                outer.mints.append(dict(permissions))
+                return f"tok{len(outer.mints)}", None
 
         def fake_call(token, method, path, payload=None):
+            self.tokens_used.append((token, method, path, payload))
             for (m, suffix), answers in responses.items():
                 if m == method and path.endswith(suffix):
                     return answers.pop(0) if len(answers) > 1 else answers[0]
             raise AssertionError(f"unexpected call {method} {path}")
 
         with mock.patch.object(wire_repo, "load_gh_token",
-                               return_value=self.FakeTokens), \
+                               return_value=FakeTokens), \
              mock.patch.object(wire_repo, "call", fake_call):
             return wire_repo.wire("o", "r", "/anywhere",
                                   branches=branches, protect=protect)
@@ -179,6 +193,7 @@ class WireTests(unittest.TestCase):
             ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
             ("POST", "/git/refs"): [(201, {}), (422, "Reference already exists")],
             ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("GET", "/repos/o/r"): [self.REPO_OK],
         })
         self.assertEqual(report["branches"],
                          {"dev": "created", "staging": "already existed"})
@@ -213,6 +228,7 @@ class WireTests(unittest.TestCase):
                 ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
                 ("POST", "/git/refs"): [(201, {})],
                 ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+                ("GET", "/repos/o/r"): [self.REPO_OK],
                 ("POST", "/rulesets"): [(201, {})],
                 ("PATCH", "/git/refs/heads/main"): [(500, "boom")],
                 ("GET", "/rules/branches/main"): [(200, [])],
@@ -226,6 +242,7 @@ class WireTests(unittest.TestCase):
             ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
             ("POST", "/git/refs"): [(201, {})],
             ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("GET", "/repos/o/r"): [self.REPO_OK],
             ("POST", "/rulesets"): [(201, {})],
             ("PATCH", "/git/refs/heads/main"):
                 [(422, "Repository rule violations found")],
@@ -236,25 +253,165 @@ class WireTests(unittest.TestCase):
         self.assertFalse(report["protected"]["main"]["enforced"])
         self.assertEqual(report["unprotected"], ["main"])
 
+    def test_ruleset_post_failure_stops_wiring(self):
+        """Recovered finding 1: a rate limit or server error on the
+        rulesets POST must exit 4 — not flow on to be summarised as a
+        plan limitation (403) or a phantom anomaly (500)."""
+        for status, detail in ((500, "boom"), (429, "rate limited"),
+                               (403, "API rate limit exceeded"),
+                               (403, "Resource not accessible by integration")):
+            with self.subTest(status=status, detail=detail):
+                with self.assertRaises(wire_repo.WiringError) as caught:
+                    self._wire({
+                        ("GET", "/git/ref/heads/main"):
+                            [(200, {"object": {"sha": "a"}})],
+                        ("POST", "/git/refs"): [(201, {})],
+                        ("PATCH", "/repos/o/r"):
+                            [(200, {"default_branch": "dev"})],
+                        ("POST", "/rulesets"): [(status, detail)],
+                    }, branches=("dev",), protect=("main",))
+                self.assertIn("never pass as an accepted plan limitation",
+                              str(caught.exception))
+
+    def test_ruleset_post_plan_limit_and_rerun_are_benign(self):
+        """The two POST refusals wiring may legitimately continue past:
+        GitHub's own plan-limit message, and a re-run's duplicate name."""
+        for status, detail in (
+                (403, "Upgrade to GitHub Pro or make this repository "
+                      "public to enable this feature."),
+                (422, "Name has already been taken")):
+            with self.subTest(status=status):
+                report = self._wire({
+                    ("GET", "/git/ref/heads/main"):
+                        [(200, {"object": {"sha": "a"}})],
+                    ("POST", "/git/refs"): [(201, {})],
+                    ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+                    ("GET", "/repos/o/r"): [self.REPO_OK],
+                    ("POST", "/rulesets"): [(status, detail)],
+                    ("PATCH", "/git/refs/heads/main"):
+                        [(422, "Repository rule violations found")],
+                    ("GET", "/rules/branches/main"): [(200, [
+                        {"type": "pull_request",
+                         "parameters": {"required_approving_review_count": 1}}])],
+                }, branches=("dev",), protect=("main",))
+                self.assertTrue(report["protected"]["main"]["enforced"])
+
+    def test_plan_limited_is_read_from_the_merge_message_not_the_status(self):
+        """Recovered finding 1: plan-ness must come from GitHub's own
+        message during verification, so a plan-limited repo carries the
+        structured marker and nothing else does."""
+        report = self._wire({
+            ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+            ("POST", "/git/refs"): [(201, {})],
+            ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("GET", "/repos/o/r"): [self.REPO_OK],
+            ("POST", "/rulesets"):
+                [(403, "Upgrade to GitHub Pro or make this repository "
+                       "public to enable this feature.")],
+            ("PATCH", "/git/refs/heads/main"): [(200, {})],
+            ("GET", "/rules/branches/main"):
+                [(403, "Upgrade to GitHub Pro or make this repository "
+                       "public to enable this feature.")],
+        }, branches=("dev",), protect=("main",))
+        self.assertTrue(report["protected"]["main"]["plan_limited"])
+        self.assertEqual(report["unprotected"], ["main"])
+
+    def test_default_branch_echo_mismatch_stops_wiring(self):
+        """Recovered finding 5: a 200 whose reported default branch is
+        not the requested one must never exit 0."""
+        with self.assertRaises(wire_repo.WiringError) as caught:
+            self._wire({
+                ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+                ("POST", "/git/refs"): [(201, {})],
+                ("PATCH", "/repos/o/r"): [(200, {"default_branch": "main"})],
+            }, branches=("dev",))
+        self.assertIn("not 'dev'", str(caught.exception))
+
+    def test_read_back_verifies_default_branch_and_merge_setting(self):
+        """Recovered findings 5 and 6: the verification pass reads the
+        repo back independently — a wrong default branch or a
+        delete-branch-on-merge that did not stick (or is invisible to
+        the token) fails wiring rather than passing silently."""
+        for repo_state in ({"default_branch": "main",
+                            "delete_branch_on_merge": False},
+                           {"default_branch": "dev",
+                            "delete_branch_on_merge": True},
+                           {"default_branch": "dev"}):
+            with self.subTest(repo_state=repo_state):
+                with self.assertRaises(wire_repo.WiringError):
+                    self._wire({
+                        ("GET", "/git/ref/heads/main"):
+                            [(200, {"object": {"sha": "a"}})],
+                        ("POST", "/git/refs"): [(201, {})],
+                        ("PATCH", "/repos/o/r"):
+                            [(200, {"default_branch": "dev"})],
+                        ("GET", "/repos/o/r"): [(200, repo_state)],
+                    }, branches=("dev",))
+
+    def test_delete_branch_on_merge_rides_the_admin_patch(self):
+        """Recovered finding 6: the setting is wired in the same PATCH
+        the admin mint already makes, not left to manual prose."""
+        self._wire({
+            ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+            ("POST", "/git/refs"): [(201, {})],
+            ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("GET", "/repos/o/r"): [self.REPO_OK],
+        }, branches=("dev",))
+        patches = [payload for token, method, path, payload in self.tokens_used
+                   if method == "PATCH" and path.endswith("/repos/o/r")]
+        self.assertEqual(patches, [{"default_branch": "dev",
+                                    "delete_branch_on_merge": False}])
+
+    def test_verification_reuses_the_unprivileged_token(self):
+        """Recovered finding 7: exactly two mints — and every probe runs
+        under the first, which never held administration."""
+        self._wire({
+            ("GET", "/git/ref/heads/main"): [(200, {"object": {"sha": "a"}})],
+            ("POST", "/git/refs"): [(201, {})],
+            ("PATCH", "/repos/o/r"): [(200, {"default_branch": "dev"})],
+            ("GET", "/repos/o/r"): [self.REPO_OK],
+            ("POST", "/rulesets"): [(201, {})],
+            ("PATCH", "/git/refs/heads/main"):
+                [(422, "Repository rule violations found")],
+            ("GET", "/rules/branches/main"): [(200, [
+                {"type": "pull_request",
+                 "parameters": {"required_approving_review_count": 1}}])],
+        }, branches=("dev",), protect=("main",))
+        self.assertEqual(self.mints,
+                         [{"contents": "write", "metadata": "read"},
+                          {"administration": "write", "metadata": "read"}])
+        probe_tokens = {token for token, method, path, payload
+                        in self.tokens_used
+                        if (method == "GET" and path.endswith("/repos/o/r"))
+                        or "/git/refs/heads/" in path   # push probe
+                        or "/rules/branches/" in path}  # merge gate
+        self.assertEqual(probe_tokens, {"tok1"},
+                         "verification must not run under the admin token")
+
 
 class ReportingTests(unittest.TestCase):
     UNPROTECTED = {
         "repo": "warblersafety/wilson", "default_branch": "dev",
+        "delete_branch_on_merge": False,
         "branches": {"dev": "created", "staging": "created"},
         "protected": {
             "main": {"ruleset_api": 403, "enforced": False,
+                     "plan_limited": True,
                      "push": "a direct write to this branch was ACCEPTED",
                      "merge": "rules unavailable on this plan for this repo"},
             "staging": {"ruleset_api": 403, "enforced": False,
+                        "plan_limited": True,
                         "push": "a direct write to this branch was ACCEPTED",
                         "merge": "rules unavailable on this plan for this repo"}},
         "unprotected": ["main", "staging"]}
 
     PROTECTED = {
         "repo": "warblersafety/scratch", "default_branch": "dev",
+        "delete_branch_on_merge": False,
         "branches": {"dev": "created", "staging": "already existed"},
         "protected": {
             "main": {"ruleset_api": 201, "enforced": True,
+                     "plan_limited": False,
                      "push": "refused by rules (422: Repository rule "
                              "violations found)",
                      "merge": "pull_request rule applies, 1 approving "
@@ -293,6 +450,27 @@ class ReportingTests(unittest.TestCase):
         self.assertIn("investigate", text)
         self.assertNotIn("PROCESS-ONLY", text)
         self.assertNotIn("accepted outcome", text)
+
+    def test_a_bare_403_status_is_not_the_plan_limitation(self):
+        """Recovered finding 1: plan-ness is the structured marker set
+        from GitHub's message during verification — a 403 POST status
+        alone (a rate limit produces one too) summarises as an anomaly,
+        never as the accepted plan outcome."""
+        report = dict(self.PROTECTED)
+        report["protected"] = {
+            "main": {"ruleset_api": 403, "enforced": False,
+                     "push": "a direct write to this branch was ACCEPTED",
+                     "merge": "no pull_request rule applies to this branch"}}
+        report["unprotected"] = ["main"]
+        text = wire_repo.summarise(report)
+        self.assertIn("RECORDED BUT NOT ENFORCED", text)
+        self.assertNotIn("PROCESS-ONLY", text)
+
+    def test_summary_carries_the_merge_setting(self):
+        """Recovered finding 6: the setting is part of the wiring report,
+        not a side conversation."""
+        self.assertIn("delete-branch-on-merge False",
+                      wire_repo.summarise(self.PROTECTED))
 
     def test_exit_code_distinguishes_unprotected_from_clean(self):
         for report, expected in ((self.PROTECTED, 0), (self.UNPROTECTED, 5)):


### PR DESCRIPTION
## Why this change

Issue #23, the last of the three App-migration units. `bootstrap` was written around a PAT that could not administer a repo, so it handed Steve a manual step per repo and its verify step checked that *he* had done it. PR #24 proved the App does all of it unattended, which left the skill describing a constraint that no longer exists — it still said "**Expect this to 403** — repo administration is outside the current token", citing Issue #14, closed. Anyone following it would have handed Steve work the App can do itself.

This also closes the interim state Grant 4 shipped into. Grant 4's preconditions name three consumers; `merge_dev.py` landed in PR #25, and this PR is the other two.

Closes #23. Closes #19.

## What changed

**Wiring is a script, not prose.** `.claude/skills/bootstrap/wire_repo.py` creates `dev`/`staging`, sets the default branch, applies the rulesets — and then **verifies what GitHub enforces, on both paths a change can take**. The push path by behaviour: a no-op fast-forward (point the ref at the sha it already holds — nothing changes either way) that must be refused *by rules*; an error — a 500, a rate limit, a dead token — means "could not verify", never "protected". The merge path by read-back: the rules GitHub reports as **applying** to the branch must include a pull_request rule requiring at least one approving review. A zero-approval rule requires *a PR*, not *a human* — any token holding `contents` + `pull_requests` write can open a PR and merge it unreviewed, demonstrated with an actual zero-approval merge to `main` on a throwaway repo (doc-review finding 1). The merge path deliberately gets a read-back rather than a behavioural probe, because its behavioural test *is* that merge, which is not harmless.

**Rulesets now require one approving human review, with an explicitly empty bypass list** — finding 1, resolved by Steve as option (a) on 2026-08-20. This repo's own `protect-main` carries the identical zero-approval shape; it is flipped in the activation beat below, **not before this PR merges**: every PR here is still PAT-authored (`smansf`), GitHub refuses self-approval, so flipping first would make this PR unmergeable.

**The trap this unit exists to close.** Free-plan rulesets cover **public** repos only, and `wilson` is deliberately private. Exit 5 still means "wired, but NOT protected" — never a pass, printed loudly, recorded in the seeded CLAUDE.md's `{{ENFORCEMENT}}` line — and its summary now says which of two very different things happened: the **plan limitation** (an accepted outcome, copied verbatim into the repo's CLAUDE.md and the central needs-Steve digest, smansf/sofa-claude Issue #2), or **recorded-but-unenforced**, an anomaly to investigate and never to record as accepted. Exit 4 now means "failed partway": its output lists exactly what had been done, or says plainly that nothing was.

**Bootstrap runs entirely on minted tokens** (finding 2). Every `gh` call in the skill goes through the workload's own `scripts/gh_token.py` — labels, standing issue, repo settings, step 6's verification reads — with no ambient fallback, and the seed template's self-falsifying "until sofa-claude #23 lands" line is replaced with the actual regime. Grant 4 now states activation as **one beat**: this merge, the PAT revocation, the `~/.claude/CLAUDE.md` rewrite, and this repo's ruleset flip happen together.

**Step 6 mints `MERGE_PERMISSIONS` verbatim**, not "a read-only token". Folded in from the PR #27 review: requesting a permission the installation has not been granted `422`s the *whole* mint, so a narrower probe goes green while the merge path is dead — precisely the sequence step 6 exists to prevent.

**`onboard` / `wrap-up`** resolve the handoff issue from the repo's own CLAUDE.md and refuse to overwrite a body that does not carry `standing` (#19). `onboard`'s credential presence check mirrors `gh_token.py`'s actual key resolution (`SOFA_APP_KEY` first, then the default path) and is marked as operator convenience, not a Grant 1 rail. `wrap-up` names the needs-Steve digest as always sofa-claude's own, whatever repo the session ran in.

## Verification

95 tests pass (was 71 before the doc-review fix round, 86 after); every new one is pinned to a finding — the probe never fails open, the merge gate rejects zero-approval rules and recognises the free-plan answer, exit 4 carries the partial report, a failed branch creation stops wiring loudly, recorded-but-unenforced reads as an anomaly, a rulesets POST failure can never pass as a plan limitation, plan-ness comes from GitHub's own message rather than a status proxy, the default branch and delete-branch-on-merge are verified by independent read-back, and verification runs under the unprivileged pre-admin token.

Live, read-only/no-op checks against real repos (2026-08-20):

```
sofa-claude main   push:  refused by rules (422: Repository rule violations found)
sofa-claude main   merge: pull_request rule requires 0 approving reviews → NOT a gate   ← detects this repo's own hole
sofa-scratch main  merge: 403 "Upgrade to GitHub Pro…" → plan limitation, not an error  ← the wilson path cannot brick
```

The original end-to-end proof (App creates the repo, wires it, both visibility paths on the same repo, no manual step) was run before the fix round and stands as proof of unattended operation; its ENFORCED verdicts reflect the old push-only probe. The two-path verification meets its first real end-to-end at the `wilson` bootstrap, where exit 5 with the plan-limitation summary is the expected outcome.

**Left behind:** nothing — Steve deleted `warblersafety/wire-test-private` on 2026-08-20.

## Review

Seam artifact — rulebook and machinery in one diff — so both lanes, and both have now run.

Adversarial doc-review ran with its brief posted first; eight findings, fix round pushed as one commit (2bafb3c). Steve then ran `/code-review medium` on that state; the session hosting it dropped after its twelve verifiers finished but before anything posted, so the findings were recovered from the run's own transcripts and posted as a comment below — seven confirmed, three plausible, two refuted. Fix round pushed as one commit (4db13c1). Nothing was re-reviewed or replicated; the recovered run is the review of record for this unit.

